### PR TITLE
fix: add z-index to sticky poll countdown

### DIFF
--- a/src/domains/polls/components/PollCountdown.tsx
+++ b/src/domains/polls/components/PollCountdown.tsx
@@ -8,7 +8,7 @@ export const PollCountdown = () => {
 	}
 
 	return (
-		<div className="p-4 text-lg text-white sticky top-0 bg-black border-b border-white">
+		<div className="p-4 text-lg text-white sticky top-0 bg-black border-b border-white z-10">
 			Next poll in {countdown.hours}h {countdown.minutes}m
 		</div>
 	);


### PR DESCRIPTION
Added this z-index to fix the <meter> element from getting trough...
<img width="789" height="112" alt="image" src="https://github.com/user-attachments/assets/f0c601f8-e137-41c8-942b-c1c13fd392e9" />
