### PR TITLE
feat: setup category group for frontend

### DIFF
--- a/drizzle/0038_brief_nightcrawler.sql
+++ b/drizzle/0038_brief_nightcrawler.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "polls_categories" ADD COLUMN "category_group" varchar(256);

--- a/drizzle/meta/0038_snapshot.json
+++ b/drizzle/meta/0038_snapshot.json
@@ -1,0 +1,1156 @@
+{
+  "id": "e80a4cdb-c7f3-46f8-91e6-79f6fa23a62c",
+  "prevId": "12504866-a48b-4aff-aa7f-90c41f3c05e9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.daily_polls": {
+      "name": "daily_polls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "daily_polls_poll_id_polls_id_fk": {
+          "name": "daily_polls_poll_id_polls_id_fk",
+          "tableFrom": "daily_polls",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_polls_date_unique": {
+          "name": "daily_polls_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leaderboard": {
+      "name": "leaderboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_code": {
+          "name": "category_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_coverage": {
+          "name": "category_coverage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_coverage": {
+          "name": "total_coverage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "best_streak": {
+          "name": "best_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "polls_answered": {
+          "name": "polls_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leaderboard_user_id_users_id_fk": {
+          "name": "leaderboard_user_id_users_id_fk",
+          "tableFrom": "leaderboard",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "leaderboard_run_id_runs_id_fk": {
+          "name": "leaderboard_run_id_runs_id_fk",
+          "tableFrom": "leaderboard",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "leaderboard_season_id_seasons_id_fk": {
+          "name": "leaderboard_season_id_seasons_id_fk",
+          "tableFrom": "leaderboard",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "leaderboard_category_code_polls_categories_code_fk": {
+          "name": "leaderboard_category_code_polls_categories_code_fk",
+          "tableFrom": "leaderboard",
+          "tableTo": "polls_categories",
+          "columnsFrom": [
+            "category_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls_categories": {
+      "name": "polls_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_group": {
+          "name": "category_group",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "polls_categories_code_unique": {
+          "name": "polls_categories_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls_history": {
+      "name": "polls_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "times_seen": {
+          "name": "times_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "times_answered": {
+          "name": "times_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_answered_at": {
+          "name": "last_answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polls_history_run_id_runs_id_fk": {
+          "name": "polls_history_run_id_runs_id_fk",
+          "tableFrom": "polls_history",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "polls_history_poll_id_polls_id_fk": {
+          "name": "polls_history_poll_id_polls_id_fk",
+          "tableFrom": "polls_history",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "polls_history_user_id_users_id_fk": {
+          "name": "polls_history_user_id_users_id_fk",
+          "tableFrom": "polls_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "polls_history_run_id_poll_id_unique": {
+          "name": "polls_history_run_id_poll_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "poll_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls_options": {
+      "name": "polls_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option": {
+          "name": "option",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct": {
+          "name": "correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polls_options_poll_id_polls_id_fk": {
+          "name": "polls_options_poll_id_polls_id_fk",
+          "tableFrom": "polls_options",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls_response_options": {
+      "name": "polls_response_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polls_response_options_response_id_polls_responses_response_id_fk": {
+          "name": "polls_response_options_response_id_polls_responses_response_id_fk",
+          "tableFrom": "polls_response_options",
+          "tableTo": "polls_responses",
+          "columnsFrom": [
+            "response_id"
+          ],
+          "columnsTo": [
+            "response_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "polls_response_options_option_id_polls_options_id_fk": {
+          "name": "polls_response_options_option_id_polls_options_id_fk",
+          "tableFrom": "polls_response_options",
+          "tableTo": "polls_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls_responses": {
+      "name": "polls_responses",
+      "schema": "",
+      "columns": {
+        "response_id": {
+          "name": "response_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polls_responses_poll_id_polls_id_fk": {
+          "name": "polls_responses_poll_id_polls_id_fk",
+          "tableFrom": "polls_responses",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "polls_responses_user_id_users_id_fk": {
+          "name": "polls_responses_user_id_users_id_fk",
+          "tableFrom": "polls_responses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls": {
+      "name": "polls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_number": {
+          "name": "poll_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_block": {
+          "name": "code_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_sandbox_example": {
+          "name": "code_sandbox_example",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "answer_type": {
+          "name": "answer_type",
+          "type": "answer_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'single'"
+        },
+        "opening_time": {
+          "name": "opening_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closing_time": {
+          "name": "closing_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "category_code": {
+          "name": "category_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polls_created_by_users_id_fk": {
+          "name": "polls_created_by_users_id_fk",
+          "tableFrom": "polls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "polls_category_code_polls_categories_code_fk": {
+          "name": "polls_category_code_polls_categories_code_fk",
+          "tableFrom": "polls",
+          "tableTo": "polls_categories",
+          "columnsFrom": [
+            "category_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_category_coverage": {
+      "name": "run_category_coverage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_code": {
+          "name": "category_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_coverage": {
+          "name": "current_coverage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "best_streak": {
+          "name": "best_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "polls_answered": {
+          "name": "polls_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "final_coverage": {
+          "name": "final_coverage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_streak": {
+          "name": "final_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_polls_answered": {
+          "name": "final_polls_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_category_coverage_run_id_runs_id_fk": {
+          "name": "run_category_coverage_run_id_runs_id_fk",
+          "tableFrom": "run_category_coverage",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_category_coverage_category_code_polls_categories_code_fk": {
+          "name": "run_category_coverage_category_code_polls_categories_code_fk",
+          "tableFrom": "run_category_coverage",
+          "tableTo": "polls_categories",
+          "columnsFrom": [
+            "category_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "run_category_coverage_run_id_category_code_unique": {
+          "name": "run_category_coverage_run_id_category_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "category_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "challenge_mode_id": {
+          "name": "challenge_mode_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_limit": {
+          "name": "storage_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1048576
+        },
+        "active_config_ids": {
+          "name": "active_config_ids",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "rerolls": {
+          "name": "rerolls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_rerolls": {
+          "name": "total_rerolls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reroll_storage_used": {
+          "name": "reroll_storage_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "shop_skipped_date": {
+          "name": "shop_skipped_date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_interacted_date": {
+          "name": "shop_interacted_date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deinstall_penalty": {
+          "name": "deinstall_penalty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "correct_polls_count": {
+          "name": "correct_polls_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completion_reason": {
+          "name": "completion_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runs_user_id_users_id_fk": {
+          "name": "runs_user_id_users_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runs_season_id_seasons_id_fk": {
+          "name": "runs_season_id_seasons_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "season_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upcoming'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roles": {
+          "name": "roles",
+          "type": "roles",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "total_polls_submitted": {
+          "name": "total_polls_submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.answer_type": {
+      "name": "answer_type",
+      "schema": "public",
+      "values": [
+        "single",
+        "multiple"
+      ]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "open",
+        "closed",
+        "archived"
+      ]
+    },
+    "public.run_status": {
+      "name": "run_status",
+      "schema": "public",
+      "values": [
+        "finished",
+        "active"
+      ]
+    },
+    "public.season_status": {
+      "name": "season_status",
+      "schema": "public",
+      "values": [
+        "upcoming",
+        "active",
+        "finished",
+        "archived"
+      ]
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1766999604349,
       "tag": "0037_chunky_greymalkin",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1767005508367,
+      "tag": "0038_brief_nightcrawler",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -204,6 +204,7 @@ export const pollCategoriesTable = pgTable("polls_categories", {
 	id: serial("id").primaryKey(),
 	name: varchar("name", { length: 256 }).notNull(),
 	code: varchar("code", { length: 256 }).notNull().unique(),
+	category_group: varchar("category_group", { length: 256 }), // Umbrella group (e.g., "Frontend Frameworks")
 });
 
 /**

--- a/src/domains/polls/components/DailyPollContainer.tsx
+++ b/src/domains/polls/components/DailyPollContainer.tsx
@@ -92,6 +92,7 @@ const DailyPollContainer = ({
 	const router = useRouter();
 	const navigate = useNavigate();
 	const category = getCategoryMetadata(poll.categoryCode);
+	console.log("DailyPollContainer render with poll ID:", poll);
 
 	// Store the score from mutation to avoid stale data after router.invalidate()
 	// The loader recalculates score with updated run data, which gives wrong values
@@ -161,7 +162,14 @@ const DailyPollContainer = ({
 			<header className="border-b border-theme py-4 mb-8">
 				<section className="flex justify-between flex-wrap gap-4">
 					<div className="flex flex-col">
-						<p className="text-4xl text-theme">{category.name}</p>
+						{category.group && (
+							<p className="text-4xl text-theme">
+								{category.group} - {category.name}
+							</p>
+						)}
+						{!category.group && (
+							<p className="text-4xl text-theme">{category.name}</p>
+						)}
 						<p>
 							#{poll.pollNumber} · Opened at{" "}
 							<time dateTime={poll.updatedAt?.toISOString()}>

--- a/src/domains/polls/components/PollForm.tsx
+++ b/src/domains/polls/components/PollForm.tsx
@@ -6,8 +6,8 @@ import rehypeHighlight from "rehype-highlight";
 import type { Poll } from "~/domains/polls/models/poll";
 import type { PollOption } from "~/domains/polls/models/pollOption";
 import {
-	CATEGORY_CODES,
 	getCategoryMetadata,
+	getGroupedCategories,
 	type CategoryCode,
 } from "~/domains/shared/categories";
 
@@ -198,11 +198,31 @@ export const PollForm = ({
 						onChange={(e) => setCategoryCode(e.target.value as CategoryCode)}
 						className="w-full bg-gray-800 border border-gray-700 rounded-lg p-3 text-theme"
 					>
-						{CATEGORY_CODES.map((code) => (
-							<option key={code} value={code}>
-								{getCategoryMetadata(code).name}
-							</option>
-						))}
+						{(() => {
+							const { grouped, ungrouped } = getGroupedCategories();
+							return (
+								<>
+									{Object.entries(grouped).map(([group, codes]) => (
+										<optgroup key={group} label={group}>
+											{codes.map((code) => (
+												<option key={code} value={code}>
+													{getCategoryMetadata(code).name}
+												</option>
+											))}
+										</optgroup>
+									))}
+									{ungrouped.length > 0 && (
+										<optgroup label="Other">
+											{ungrouped.map((code) => (
+												<option key={code} value={code}>
+													{getCategoryMetadata(code).name}
+												</option>
+											))}
+										</optgroup>
+									)}
+								</>
+							);
+						})()}
 					</select>
 				</div>
 

--- a/src/domains/polls/services/dailyPoll.service.ts
+++ b/src/domains/polls/services/dailyPoll.service.ts
@@ -18,7 +18,7 @@ export const getDateSeed = (date?: string): string => {
  * Uses daily_polls table for O(1) lookup on subsequent requests
  */
 export const selectDailyPoll = async (date?: string): Promise<Poll | null> => {
-	const dateSeed = getDateSeed(date);
+	const dateSeed = getDateSeed("2025-01-16" /*date*/);
 
 	const selectPollForDate = (polls: Poll[]) =>
 		selectSeededRandom(polls, dateSeed);

--- a/src/domains/shared/categories.ts
+++ b/src/domains/shared/categories.ts
@@ -11,26 +11,39 @@ export const CATEGORY_CODES = [
 	"html",
 	"git",
 	"general-frontend",
+	"vue",
+	"angular",
+	"nextjs",
 ] as const;
 export type CategoryCode = (typeof CATEGORY_CODES)[number];
 
-export const CATEGORY_METADATA = {
+export const CATEGORY_GROUPS = ["Frontend Frameworks"] as const;
+export type CategoryGroup = (typeof CATEGORY_GROUPS)[number];
+
+type CategoryMeta = { name: string; group?: CategoryGroup };
+
+export const CATEGORY_METADATA: Record<CategoryCode, CategoryMeta> = {
 	css: { name: "CSS" },
 	js: { name: "JavaScript" },
-	react: { name: "React" },
 	ts: { name: "TypeScript" },
-	git: { name: "Git" },
 	html: { name: "HTML" },
+	git: { name: "Git" },
 	"general-frontend": { name: "General Frontend" },
-} as const satisfies Record<CategoryCode, { name: string }>;
+	// Frontend Frameworks group:
+	react: { name: "React", group: "Frontend Frameworks" },
+	vue: { name: "Vue", group: "Frontend Frameworks" },
+	angular: { name: "Angular", group: "Frontend Frameworks" },
+	nextjs: { name: "Next.js", group: "Frontend Frameworks" },
+};
 
 /**
- * Get categories with both code and name for UI components and database operations
+ * Get categories with code, name, and group for UI components and database operations
  */
 export const getCategories = () =>
 	CATEGORY_CODES.map((code) => ({
 		code,
 		name: CATEGORY_METADATA[code].name,
+		category_group: CATEGORY_METADATA[code].group ?? null,
 	}));
 
 /**
@@ -38,3 +51,30 @@ export const getCategories = () =>
  */
 export const getCategoryMetadata = (categoryCode: CategoryCode) =>
 	CATEGORY_METADATA[categoryCode];
+
+/**
+ * Get all category codes that belong to a specific group
+ */
+export const getCategoriesByGroup = (group: CategoryGroup): CategoryCode[] =>
+	CATEGORY_CODES.filter((code) => CATEGORY_METADATA[code].group === group);
+
+/**
+ * Get categories organized by their groups
+ * Returns { grouped: { "Frontend Frameworks": ["react", "vue", ...] }, ungrouped: ["css", "js", ...] }
+ */
+export const getGroupedCategories = () => {
+	const grouped: Partial<Record<CategoryGroup, CategoryCode[]>> = {};
+	const ungrouped: CategoryCode[] = [];
+
+	for (const code of CATEGORY_CODES) {
+		const group = CATEGORY_METADATA[code].group;
+		if (group) {
+			grouped[group] = grouped[group] || [];
+			grouped[group].push(code);
+		} else {
+			ungrouped.push(code);
+		}
+	}
+
+	return { grouped, ungrouped };
+};

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -311,8 +311,11 @@
 	--meter-bg: oklch(from var(--color-fuchsia) calc(l - 0.25) c h);
 }
 
-/* React category */
-[data-category-theme="react"] {
+/* Frontend frameworks */
+[data-category-theme="react"],
+[data-category-theme="angular"],
+[data-category-theme="vue"],
+[data-category-theme="nextjs"] {
 	.text-theme {
 		color: var(--color-celadon);
 	}
@@ -384,4 +387,3 @@ meter::-webkit-meter-optimum-value {
 	background: var(--meter-fill);
 	border-radius: inherit;
 }
-


### PR DESCRIPTION
Can't merge yet. 

Opposes a game design problem, because I haven't though of: 
- How will scoring work? Do we get a seperate category or score as category group? Vue, React, Angular and Next.js ARE categories technically. 
- What if someone is very good at Angular? And not at Vue? 
- How do we display this in de scoring overview? 
- Do I want multiple configs for each framework? 



Don't forget to run prod migration if merging: 



```
  ALTER TABLE "polls_categories" ADD COLUMN "category_group" varchar(256);
  INSERT INTO "polls_categories" (name, code, category_group) VALUES
    ('Vue', 'vue', 'Frontend Frameworks'),
    ('Angular', 'angular', 'Frontend Frameworks'),
    ('Next.js', 'nextjs', 'Frontend Frameworks');
  UPDATE "polls_categories" SET category_group = 'Frontend Frameworks' WHERE code = 'react';
```