### PR TITLE
fix: restore fastest responder by handling NULL run_ids in join

### DIFF
--- a/src/domains/polls/api/queries.ts
+++ b/src/domains/polls/api/queries.ts
@@ -9,6 +9,7 @@ import {
 	inArray,
 	or,
 	not,
+	isNull,
 } from "drizzle-orm";
 
 import { db } from "~/database/db";
@@ -468,7 +469,10 @@ export const getCommunityStatsForDailyPoll = async (
 			and(
 				eq(pollHistoryTable.poll_id, pollResponsesTable.poll_id),
 				eq(pollHistoryTable.user_id, pollResponsesTable.user_id),
-				eq(pollHistoryTable.run_id, pollResponsesTable.run_id)
+				or(
+					eq(pollHistoryTable.run_id, pollResponsesTable.run_id),
+					isNull(pollResponsesTable.run_id)
+				)
 			)
 		);
 


### PR DESCRIPTION
The previous commit added run_id to the poll history join, but this
broke backwards compatibility for responses with NULL run_id (created
before run_id was added). NULL = NULL is false in SQL, causing the
join to return no poll history, making timeTakenMs null for everyone.