### PR TITLE
fix: clean up gate requirements and make Try/Catch persistent

### DIFF
--- a/src/domains/configs/data/configs.ts
+++ b/src/domains/configs/data/configs.ts
@@ -153,9 +153,9 @@ export const configs: Config[] = [
 		id: "try-catch-config",
 		name: "Try/Catch",
 		image: "/configs/try-catch.png",
-		cost: STORAGE_UNITS.MB / 2,
+		cost: (STORAGE_UNITS.MB / 2) * 1.5,
 		description:
-			"Saves your run when you have at least 80% of the coverage threshold. Can activate multiple times per run.",
+			"Saves your run when you have at least 80% of the coverage threshold.",
 		rarity: "rare",
 		effect: ["checkCoverageWithThreshold"],
 		priority: 100,

--- a/src/domains/configs/data/configs.ts
+++ b/src/domains/configs/data/configs.ts
@@ -149,14 +149,13 @@ export const configs: Config[] = [
 		coverageBonus: 0.5,
 		targetCategories: [],
 	},
-	// TODO: re-enable try/catch config when refactored
 	{
 		id: "try-catch-config",
 		name: "Try/Catch",
 		image: "/configs/try-catch.png",
 		cost: STORAGE_UNITS.MB / 2,
 		description:
-			"Saves your run when you have at least 80% of the coverage threshold. When activated, this config is consumed.",
+			"Saves your run when you have at least 80% of the coverage threshold. Can activate multiple times per run.",
 		rarity: "rare",
 		effect: ["checkCoverageWithThreshold"],
 		priority: 100,

--- a/src/domains/configs/data/configs.ts
+++ b/src/domains/configs/data/configs.ts
@@ -19,7 +19,7 @@ export const configs: Config[] = [
 		targetCategories: ["html"],
 		priority: 100,
 		coverageBonus: 2,
-		categoryWeightBonus: 0.1,
+		categoryWeightBonus: 0.3,
 	},
 	{
 		id: ".css-config",
@@ -33,7 +33,7 @@ export const configs: Config[] = [
 		targetCategories: ["css"],
 		priority: 100,
 		coverageBonus: 2,
-		categoryWeightBonus: 0.1,
+		categoryWeightBonus: 0.3,
 	},
 	{
 		id: ".js-config",
@@ -47,7 +47,7 @@ export const configs: Config[] = [
 		targetCategories: ["js"],
 		priority: 100,
 		coverageBonus: 2,
-		categoryWeightBonus: 0.1,
+		categoryWeightBonus: 0.3,
 	},
 	{
 		id: ".ts-config",
@@ -61,7 +61,7 @@ export const configs: Config[] = [
 		targetCategories: ["ts"],
 		priority: 100,
 		coverageBonus: 2,
-		categoryWeightBonus: 0.1,
+		categoryWeightBonus: 0.3,
 	},
 	{
 		id: ".jsx-config",
@@ -75,7 +75,7 @@ export const configs: Config[] = [
 		targetCategories: ["react"],
 		priority: 100,
 		coverageBonus: 2,
-		categoryWeightBonus: 0.1,
+		categoryWeightBonus: 0.3,
 	},
 	{
 		id: ".git-config",
@@ -89,7 +89,7 @@ export const configs: Config[] = [
 		targetCategories: ["git"],
 		priority: 100,
 		coverageBonus: 2,
-		categoryWeightBonus: 0.1,
+		categoryWeightBonus: 0.3,
 	},
 	{
 		id: "package.json-config",
@@ -103,7 +103,7 @@ export const configs: Config[] = [
 		targetCategories: ["general-frontend"],
 		priority: 100,
 		coverageBonus: 2,
-		categoryWeightBonus: 0.1,
+		categoryWeightBonus: 0.3,
 	},
 	{
 		id: "local-storage-config",
@@ -295,7 +295,7 @@ export const configs: Config[] = [
 		rarity: "uncommon",
 		effect: [],
 		priority: 100,
-		categoryWeightBonus: 0.5,
+		categoryWeightBonus: 1.1,
 		targetCategories: ["html"],
 	},
 	{
@@ -307,7 +307,7 @@ export const configs: Config[] = [
 		rarity: "uncommon",
 		effect: [],
 		priority: 100,
-		categoryWeightBonus: 0.5,
+		categoryWeightBonus: 1.1,
 		targetCategories: ["css"],
 	},
 	{
@@ -320,7 +320,7 @@ export const configs: Config[] = [
 		rarity: "uncommon",
 		effect: [],
 		priority: 100,
-		categoryWeightBonus: 0.5,
+		categoryWeightBonus: 1.1,
 		targetCategories: ["js"],
 	},
 	{
@@ -332,7 +332,7 @@ export const configs: Config[] = [
 		rarity: "uncommon",
 		effect: [],
 		priority: 100,
-		categoryWeightBonus: 0.5,
+		categoryWeightBonus: 1.1,
 		targetCategories: ["git"],
 	},
 	{
@@ -345,7 +345,7 @@ export const configs: Config[] = [
 		rarity: "uncommon",
 		effect: [],
 		priority: 100,
-		categoryWeightBonus: 0.5,
+		categoryWeightBonus: 1.1,
 		targetCategories: ["react"],
 	},
 	{
@@ -358,7 +358,7 @@ export const configs: Config[] = [
 		rarity: "uncommon",
 		effect: [],
 		priority: 100,
-		categoryWeightBonus: 0.5,
+		categoryWeightBonus: 1.1,
 		targetCategories: ["ts"],
 	},
 	{
@@ -371,7 +371,7 @@ export const configs: Config[] = [
 		rarity: "uncommon",
 		effect: [],
 		priority: 100,
-		categoryWeightBonus: 0.5,
+		categoryWeightBonus: 1.1,
 		targetCategories: ["general-frontend"],
 	},
 ];

--- a/src/domains/polls/services/processPollAnswer.service.ts
+++ b/src/domains/polls/services/processPollAnswer.service.ts
@@ -1,4 +1,3 @@
-import { removeConfigFromRunQuery } from "~/domains/configs/api/queries";
 import { applyEffects } from "~/domains/configs/data/configs";
 import {
 	createPollResponse,
@@ -142,8 +141,7 @@ export const processPollAnswer = async (
 
 	if (!thresholdInfo.meetsThreshold) {
 		if (protection.tryCatch) {
-			// Try/Catch saves the run! Remove the config since it's one-time use
-			await removeConfigFromRunQuery(activeRun.id, ["try-catch-config"]);
+			// Try/Catch saves the run! Config persists for future use
 			tryCatchUsed = true;
 			// Don't end the run - try/catch saved it
 		} else {

--- a/src/domains/runs/data/gates/vanilla.ts
+++ b/src/domains/runs/data/gates/vanilla.ts
@@ -48,7 +48,7 @@ export const VANILLA_CI_GATES: GateDefinition[] = [
 	{
 		gate: 5,
 		requirements: [{ threshold: 24, requiredCategories: 2 }],
-		evaluationMode: "OR",
+		evaluationMode: "AND",
 		pollsPerGate: 5,
 	},
 	{
@@ -63,7 +63,7 @@ export const VANILLA_CI_GATES: GateDefinition[] = [
 	{
 		gate: 7,
 		requirements: [{ threshold: 35, requiredCategories: 2 }],
-		evaluationMode: "OR",
+		evaluationMode: "AND",
 		pollsPerGate: 5,
 	},
 	{

--- a/src/domains/runs/data/gates/vanilla.ts
+++ b/src/domains/runs/data/gates/vanilla.ts
@@ -47,11 +47,8 @@ export const VANILLA_CI_GATES: GateDefinition[] = [
 	},
 	{
 		gate: 5,
-		requirements: [
-			{ threshold: 24, requiredCategories: 1 },
-			{ threshold: 24, requiredCategories: 1 },
-		],
-		evaluationMode: "AND",
+		requirements: [{ threshold: 24, requiredCategories: 2 }],
+		evaluationMode: "OR",
 		pollsPerGate: 5,
 	},
 	{
@@ -65,11 +62,8 @@ export const VANILLA_CI_GATES: GateDefinition[] = [
 	},
 	{
 		gate: 7,
-		requirements: [
-			{ threshold: 35, requiredCategories: 1 },
-			{ threshold: 35, requiredCategories: 1 },
-		],
-		evaluationMode: "AND",
+		requirements: [{ threshold: 35, requiredCategories: 2 }],
+		evaluationMode: "OR",
 		pollsPerGate: 5,
 	},
 	{

--- a/src/domains/runs/services/thresholdCalculator.service.spec.ts
+++ b/src/domains/runs/services/thresholdCalculator.service.spec.ts
@@ -69,10 +69,7 @@ describe("ThresholdCalculator", () => {
 
 			expect(gate).toEqual({
 				gate: 5,
-				requirements: [
-					{ threshold: 24, requiredCategories: 1 },
-					{ threshold: 24, requiredCategories: 1 },
-				],
+				requirements: [{ threshold: 24, requiredCategories: 2 }],
 				evaluationMode: "AND",
 				pollsPerGate: 5,
 			});
@@ -97,10 +94,7 @@ describe("ThresholdCalculator", () => {
 
 			expect(gate).toEqual({
 				gate: 7,
-				requirements: [
-					{ threshold: 35, requiredCategories: 1 },
-					{ threshold: 35, requiredCategories: 1 },
-				],
+				requirements: [{ threshold: 35, requiredCategories: 2 }],
 				evaluationMode: "AND",
 				pollsPerGate: 5,
 			});


### PR DESCRIPTION
- Gate 5 and 7: consolidate duplicate requirements into single
  requirement with requiredCategories: 2 (cleaner semantics, same logic)
- Try/Catch: now persists for entire run instead of being consumed
  on first activation (can save player multiple times)