### PR TITLE
feat: enable post-victory mode for continuing runs after all gates passed

### DIFF
--- a/drizzle/0041_spotty_kree.sql
+++ b/drizzle/0041_spotty_kree.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "runs" ADD COLUMN "victory_achieved_at" timestamp with time zone;

--- a/drizzle/0041_victory_achieved_at.sql
+++ b/drizzle/0041_victory_achieved_at.sql
@@ -1,0 +1,2 @@
+-- Add victory_achieved_at column to runs table for post-victory mode
+ALTER TABLE "runs" ADD COLUMN "victory_achieved_at" timestamp with time zone;

--- a/drizzle/meta/0041_snapshot.json
+++ b/drizzle/meta/0041_snapshot.json
@@ -1,0 +1,1197 @@
+{
+  "id": "40473a85-a772-42a2-9a57-efcf363dba21",
+  "prevId": "1885b57e-15ba-4478-b0be-f3ac62ccfea3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.daily_polls": {
+      "name": "daily_polls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_weights": {
+          "name": "category_weights",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "daily_polls_poll_id_polls_id_fk": {
+          "name": "daily_polls_poll_id_polls_id_fk",
+          "tableFrom": "daily_polls",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_polls_date_unique": {
+          "name": "daily_polls_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leaderboard": {
+      "name": "leaderboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_code": {
+          "name": "category_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_coverage": {
+          "name": "category_coverage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_coverage": {
+          "name": "total_coverage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "best_streak": {
+          "name": "best_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "polls_answered": {
+          "name": "polls_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leaderboard_user_id_users_id_fk": {
+          "name": "leaderboard_user_id_users_id_fk",
+          "tableFrom": "leaderboard",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "leaderboard_run_id_runs_id_fk": {
+          "name": "leaderboard_run_id_runs_id_fk",
+          "tableFrom": "leaderboard",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "leaderboard_season_id_seasons_id_fk": {
+          "name": "leaderboard_season_id_seasons_id_fk",
+          "tableFrom": "leaderboard",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "leaderboard_category_code_polls_categories_code_fk": {
+          "name": "leaderboard_category_code_polls_categories_code_fk",
+          "tableFrom": "leaderboard",
+          "tableTo": "polls_categories",
+          "columnsFrom": [
+            "category_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls_categories": {
+      "name": "polls_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "polls_categories_code_unique": {
+          "name": "polls_categories_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls_history": {
+      "name": "polls_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "times_seen": {
+          "name": "times_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "times_answered": {
+          "name": "times_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_answered_at": {
+          "name": "last_answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polls_history_run_id_runs_id_fk": {
+          "name": "polls_history_run_id_runs_id_fk",
+          "tableFrom": "polls_history",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "polls_history_poll_id_polls_id_fk": {
+          "name": "polls_history_poll_id_polls_id_fk",
+          "tableFrom": "polls_history",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "polls_history_user_id_users_id_fk": {
+          "name": "polls_history_user_id_users_id_fk",
+          "tableFrom": "polls_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "polls_history_run_id_poll_id_unique": {
+          "name": "polls_history_run_id_poll_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "poll_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls_options": {
+      "name": "polls_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option": {
+          "name": "option",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct": {
+          "name": "correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polls_options_poll_id_polls_id_fk": {
+          "name": "polls_options_poll_id_polls_id_fk",
+          "tableFrom": "polls_options",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls_response_options": {
+      "name": "polls_response_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polls_response_options_response_id_polls_responses_response_id_fk": {
+          "name": "polls_response_options_response_id_polls_responses_response_id_fk",
+          "tableFrom": "polls_response_options",
+          "tableTo": "polls_responses",
+          "columnsFrom": [
+            "response_id"
+          ],
+          "columnsTo": [
+            "response_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "polls_response_options_option_id_polls_options_id_fk": {
+          "name": "polls_response_options_option_id_polls_options_id_fk",
+          "tableFrom": "polls_response_options",
+          "tableTo": "polls_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls_responses": {
+      "name": "polls_responses",
+      "schema": "",
+      "columns": {
+        "response_id": {
+          "name": "response_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_date": {
+          "name": "answer_date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polls_responses_poll_id_polls_id_fk": {
+          "name": "polls_responses_poll_id_polls_id_fk",
+          "tableFrom": "polls_responses",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "polls_responses_user_id_users_id_fk": {
+          "name": "polls_responses_user_id_users_id_fk",
+          "tableFrom": "polls_responses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "polls_responses_run_id_runs_id_fk": {
+          "name": "polls_responses_run_id_runs_id_fk",
+          "tableFrom": "polls_responses",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "polls_responses_poll_id_user_id_answer_date_unique": {
+          "name": "polls_responses_poll_id_user_id_answer_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "poll_id",
+            "user_id",
+            "answer_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls": {
+      "name": "polls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_number": {
+          "name": "poll_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_block": {
+          "name": "code_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_sandbox_example": {
+          "name": "code_sandbox_example",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "answer_type": {
+          "name": "answer_type",
+          "type": "answer_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'single'"
+        },
+        "opening_time": {
+          "name": "opening_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closing_time": {
+          "name": "closing_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "category_code": {
+          "name": "category_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polls_created_by_users_id_fk": {
+          "name": "polls_created_by_users_id_fk",
+          "tableFrom": "polls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "polls_category_code_polls_categories_code_fk": {
+          "name": "polls_category_code_polls_categories_code_fk",
+          "tableFrom": "polls",
+          "tableTo": "polls_categories",
+          "columnsFrom": [
+            "category_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_category_coverage": {
+      "name": "run_category_coverage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_code": {
+          "name": "category_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_coverage": {
+          "name": "current_coverage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "best_streak": {
+          "name": "best_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "polls_answered": {
+          "name": "polls_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "final_coverage": {
+          "name": "final_coverage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_streak": {
+          "name": "final_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_polls_answered": {
+          "name": "final_polls_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_category_coverage_run_id_runs_id_fk": {
+          "name": "run_category_coverage_run_id_runs_id_fk",
+          "tableFrom": "run_category_coverage",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_category_coverage_category_code_polls_categories_code_fk": {
+          "name": "run_category_coverage_category_code_polls_categories_code_fk",
+          "tableFrom": "run_category_coverage",
+          "tableTo": "polls_categories",
+          "columnsFrom": [
+            "category_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "run_category_coverage_run_id_category_code_unique": {
+          "name": "run_category_coverage_run_id_category_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "category_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "challenge_mode_id": {
+          "name": "challenge_mode_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_limit": {
+          "name": "storage_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1048576
+        },
+        "active_config_ids": {
+          "name": "active_config_ids",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "rerolls": {
+          "name": "rerolls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_rerolls": {
+          "name": "total_rerolls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reroll_storage_used": {
+          "name": "reroll_storage_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "shop_skipped_date": {
+          "name": "shop_skipped_date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_interacted_date": {
+          "name": "shop_interacted_date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deinstall_penalty": {
+          "name": "deinstall_penalty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "correct_polls_count": {
+          "name": "correct_polls_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completion_reason": {
+          "name": "completion_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "victory_achieved_at": {
+          "name": "victory_achieved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runs_user_id_users_id_fk": {
+          "name": "runs_user_id_users_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runs_season_id_seasons_id_fk": {
+          "name": "runs_season_id_seasons_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "season_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upcoming'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roles": {
+          "name": "roles",
+          "type": "roles",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "total_polls_submitted": {
+          "name": "total_polls_submitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.answer_type": {
+      "name": "answer_type",
+      "schema": "public",
+      "values": [
+        "single",
+        "multiple"
+      ]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "open",
+        "closed",
+        "archived"
+      ]
+    },
+    "public.run_status": {
+      "name": "run_status",
+      "schema": "public",
+      "values": [
+        "finished",
+        "active"
+      ]
+    },
+    "public.season_status": {
+      "name": "season_status",
+      "schema": "public",
+      "values": [
+        "upcoming",
+        "active",
+        "finished",
+        "archived"
+      ]
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1767696198158,
       "tag": "0040_fast_chimera",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1767871873393,
+      "tag": "0041_spotty_kree",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -295,6 +295,7 @@ export const runsTable = pgTable("runs", {
 	deinstall_penalty: integer("deinstall_penalty").notNull().default(0), // Storage penalty from deinstalling configs
 	correct_polls_count: integer("correct_polls_count").notNull().default(0), // Number of correctly answered polls in this run
 	completion_reason: varchar("completion_reason", { length: 50 }), // Reason for run completion: "victory", "threshold_not_met", "wrong_answer", "manual_break_off"
+	victory_achieved_at: timestamp("victory_achieved_at", { withTimezone: true }), // When player passed all gates (run continues in post-victory mode)
 	started_at: timestamp("started_at", { withTimezone: true }).defaultNow(),
 	finished_at: timestamp("finished_at", { withTimezone: true }),
 	created_at: timestamp("created_at", { withTimezone: true }).defaultNow(),

--- a/src/domains/polls/components/DailyPollContainer.tsx
+++ b/src/domains/polls/components/DailyPollContainer.tsx
@@ -168,8 +168,21 @@ const DailyPollContainer = ({
 	// Use the submitted score if available (just answered), otherwise fall back to loader's score
 	const displayScore = submittedScore ?? score;
 
+	const isInPostVictoryMode = activeRun.victoryAchievedAt !== null;
+
 	return (
 		<section>
+			{isInPostVictoryMode && (
+				<div className="mb-6 p-4 border-2 border-green-500 bg-green-500/10">
+					<p className="text-green-400 text-lg font-bold">
+						You passed all CI gates!
+					</p>
+					<p className="text-gray-300 text-sm">
+						You&apos;re now in post-victory mode. Keep playing to reach 100%
+						coverage or start a new run anytime.
+					</p>
+				</div>
+			)}
 			{isAdmin && (
 				<div className="mb-4 pb-2 border-b border-gray-700">
 					<Link
@@ -177,7 +190,7 @@ const DailyPollContainer = ({
 						params={{ pollId: String(poll.id) }}
 						className="text-primary hover:text-primary/80 hover:underline text-sm"
 					>
-						✏️ Edit Poll
+						Edit Poll
 					</Link>
 				</div>
 			)}
@@ -192,6 +205,7 @@ const DailyPollContainer = ({
 					<GateProgressIndicator
 						gate={currentGate}
 						categoryCoverage={activeRun.categoryCoverage}
+						victoryAchievedAt={activeRun.victoryAchievedAt}
 					/>
 				</section>
 			</header>

--- a/src/domains/polls/services/processPollAnswer.service.ts
+++ b/src/domains/polls/services/processPollAnswer.service.ts
@@ -36,6 +36,7 @@ export type PollAnswerResult = {
 	outcome: PollAnswerOutcome;
 	breakdown: PollScoreBreakdown | null;
 	tryCatchUsed?: boolean;
+	victoryJustAchieved?: boolean;
 };
 
 export type PollAnswerInput = {
@@ -111,18 +112,24 @@ export const processPollAnswer = async (
 
 	let runEnded = false;
 	let tryCatchUsed = false;
+	let victoryJustAchieved = false;
 
 	// TODO: Refactor this so we can handle endless config possibilities
 	// This is done for now like so because of MVP
 	// Check if try/catch protection should prevent run failure
 	// Check for victory at CI gates (when last defined gate is passed)
+	// Victory no longer ends the run - player enters post-victory mode and can continue playing
 	if (thresholdInfo.meetsThreshold && thresholdInfo.isThresholdCheckPoll) {
-		const { checkForVictory, completeRunWithVictory } =
+		const { checkForVictory } =
 			await import("~/domains/runs/services/runCompletion.service");
 		const hasWon = checkForVictory(thresholdInfo.currentGate, gates);
-		if (hasWon) {
-			await completeRunWithVictory(activeRun.id);
-			runEnded = true;
+		if (hasWon && !updatedRun.victoryAchievedAt) {
+			// Mark victory but don't end the run - player can continue in post-victory mode
+			const { markVictoryAchieved } =
+				await import("~/domains/runs/api/queries");
+			await markVictoryAchieved(activeRun.id);
+			victoryJustAchieved = true;
+			// runEnded stays false - player continues playing
 		}
 	}
 
@@ -169,6 +176,7 @@ export const processPollAnswer = async (
 		thresholdInfo,
 		breakdown,
 		tryCatchUsed,
+		victoryJustAchieved,
 	};
 };
 

--- a/src/domains/runs/api/queries.ts
+++ b/src/domains/runs/api/queries.ts
@@ -120,6 +120,19 @@ export const finishRun = async (runId: number) => {
 	return runRecord ? runFactory.toDTO(runRecord) : null;
 };
 
+// Mark victory achieved without ending the run (post-victory mode)
+export const markVictoryAchieved = async (runId: number) => {
+	const [runRecord] = await db
+		.update(runsTable)
+		.set({
+			victory_achieved_at: new Date(),
+		})
+		.where(eq(runsTable.id, runId))
+		.returning();
+
+	return runRecord ? runFactory.toDTO(runRecord) : null;
+};
+
 export const getRunStats = async (runId: number) => {
 	const stats = await db
 		.select()

--- a/src/domains/runs/components/GateProgressIndicator.tsx
+++ b/src/domains/runs/components/GateProgressIndicator.tsx
@@ -5,12 +5,32 @@ import { getCategoryMetadata } from "~/domains/shared/categories";
 type GateProgressIndicatorProps = {
 	gate: GateDefinition;
 	categoryCoverage: RunCategoryCoverage[];
+	victoryAchievedAt?: Date | null;
 };
 
 const GateProgressIndicator = ({
 	gate,
 	categoryCoverage,
+	victoryAchievedAt,
 }: GateProgressIndicatorProps) => {
+	// Post-victory mode: show completion status instead of next gate requirements
+	if (victoryAchievedAt) {
+		const totalCoverage = categoryCoverage.reduce(
+			(sum, cat) => sum + cat.currentCoverage,
+			0
+		);
+
+		return (
+			<div className="text-right">
+				<p className="text-green-400 text-xl font-bold">All Gates Complete!</p>
+				<p className="text-gray-300 text-sm">
+					Total coverage: {totalCoverage.toFixed(1)}%
+				</p>
+				<p className="text-gray-400 text-xs">Post-victory mode</p>
+			</div>
+		);
+	}
+
 	const sortedCategories = [...categoryCoverage].sort(
 		(a, b) => b.currentCoverage - a.currentCoverage
 	);

--- a/src/domains/runs/models/run.ts
+++ b/src/domains/runs/models/run.ts
@@ -20,6 +20,7 @@ export type Run = {
 	shopSkippedDate: string | null;
 	shopInteractedDate: string | null;
 	completionReason: string | null;
+	victoryAchievedAt: Date | null;
 	startedAt: Date;
 	finishedAt: Date | null;
 	createdAt: Date;
@@ -54,6 +55,7 @@ export const runToDTO = (
 		updatedAt: record.updated_at,
 		categoryCoverage,
 		completionReason: record.completion_reason,
+		victoryAchievedAt: record.victory_achieved_at,
 		deinstallPenalty: record.deinstall_penalty,
 		correctPollsCount: record.correct_polls_count,
 	};
@@ -78,6 +80,7 @@ export const runFromDTO = (dto: Run): RunRecord => {
 		created_at: dto.createdAt,
 		updated_at: dto.updatedAt,
 		completion_reason: dto.completionReason || null,
+		victory_achieved_at: dto.victoryAchievedAt || null,
 		deinstall_penalty: dto.deinstallPenalty || 0,
 		correct_polls_count: dto.correctPollsCount || 0,
 	};
@@ -108,6 +111,7 @@ export const createRun = (partial: Partial<Run> = {}): Run => {
 		shopSkippedDate: null,
 		shopInteractedDate: null,
 		completionReason: null,
+		victoryAchievedAt: null,
 		startedAt: now,
 		finishedAt: null,
 		createdAt: now,
@@ -135,6 +139,7 @@ export const createMockRun = (overrides: Partial<Run> = {}): Run => {
 		shopSkippedDate: null,
 		shopInteractedDate: null,
 		completionReason: null,
+		victoryAchievedAt: null,
 		startedAt: new Date("2024-01-01T00:00:00Z"),
 		finishedAt: null,
 		createdAt: new Date("2024-01-01T00:00:00Z"),
@@ -151,6 +156,7 @@ export const createMockRunRecord = (
 ): RunRecord => {
 	return {
 		completion_reason: null,
+		victory_achieved_at: null,
 		id: 1,
 		user_id: "test-user-id",
 		season_id: 1,

--- a/src/domains/runs/services/runCompletion.service.ts
+++ b/src/domains/runs/services/runCompletion.service.ts
@@ -81,13 +81,13 @@ export const checkCoverageThreshold = async (
 };
 
 // Check if player has passed all defined CI gates (victory condition)
-// Victory occurs when current round exceeds the number of defined gates
-// Example: With 7 gates defined, round 8 means gate 7 was just passed
+// Victory occurs when player passes the threshold check of the last gate
+// Example: With 7 gates defined, victory triggers when gate 7's threshold is met
 export const checkForVictory = (
-	currentRound: number,
+	currentGate: number,
 	gates: GateDefinition[]
 ): boolean => {
-	return currentRound > gates.length;
+	return currentGate >= gates.length;
 };
 
 // Complete run with victory (all defined CI gates passed)

--- a/src/domains/runs/services/thresholdCalculator.service.ts
+++ b/src/domains/runs/services/thresholdCalculator.service.ts
@@ -21,6 +21,30 @@ export type GateDefinition = {
 	pollsPerGate: number;
 };
 
+const POST_VICTORY_THRESHOLD_INCREMENT = 5;
+
+/**
+ * Generates a virtual gate for post-victory mode
+ * Uses linear scaling: each gate beyond victory adds +5 to all thresholds
+ */
+export const generatePostVictoryGate = (
+	lastDefinedGate: GateDefinition,
+	gateNumber: number
+): GateDefinition => {
+	const gatesBeyondLast = gateNumber - lastDefinedGate.gate;
+	const thresholdIncrease = gatesBeyondLast * POST_VICTORY_THRESHOLD_INCREMENT;
+
+	return {
+		gate: gateNumber,
+		requirements: lastDefinedGate.requirements.map((req) => ({
+			...req,
+			threshold: Math.min(req.threshold + thresholdIncrease, 100),
+		})),
+		evaluationMode: lastDefinedGate.evaluationMode,
+		pollsPerGate: lastDefinedGate.pollsPerGate,
+	};
+};
+
 /**
  * Result of evaluating a single gate requirement
  */
@@ -73,8 +97,13 @@ export const getCurrentGate = (
 		}
 	}
 
-	// Beyond all defined gates - return last gate
-	return gates[gates.length - 1];
+	// Beyond all defined gates - generate post-victory gate
+	const lastGate = gates[gates.length - 1];
+	const pollsBeyondDefined = totalPollsSeen - pollsAccumulated;
+	const postVictoryGateNumber =
+		lastGate.gate + Math.floor(pollsBeyondDefined / lastGate.pollsPerGate) + 1;
+
+	return generatePostVictoryGate(lastGate, postVictoryGateNumber);
 };
 
 /**

--- a/src/routes/_authed/game-over.tsx
+++ b/src/routes/_authed/game-over.tsx
@@ -137,8 +137,8 @@ function RouteComponent() {
 								Congratulations on mastering all CI gates! You can continue your
 								run and try to reach the perfect 100% coverage!
 							</p>
-							<PrimaryButton className="px-3 py-1 mr-4" disabled={true}>
-								Continue run
+							<PrimaryButton className="px-3 py-1 mr-4">
+								<Link to="/daily-poll">Continue Run</Link>
 							</PrimaryButton>
 							<span className="text-gray-400">
 								Or start a new run below with a another set of CI gates!

--- a/src/routes/_authed/progress.tsx
+++ b/src/routes/_authed/progress.tsx
@@ -242,46 +242,58 @@ function RouteComponent() {
 				<section className="grid grid-cols-1 md:grid-cols-2 gap-8">
 					<div className="space-y-4">
 						<h3 className="text-xl">Gate Progress</h3>
-						{gates.slice(0, currentGate.gate).map((gate) => {
-							const status = getGateStatus(gate.gate, currentGate.gate);
-							const isCurrent = gate.gate === currentGate.gate;
+						{(() => {
+							// Include post-victory gate if we're beyond defined gates
+							const isPostVictory = currentGate.gate > gates.length;
+							const displayGates = isPostVictory
+								? [...gates, currentGate]
+								: gates.slice(0, currentGate.gate);
 
-							return (
-								<details
-									key={gate.gate}
-									className={`group border-b border-t border-white py-4 ${isCurrent ? "bg-white/5" : ""}`}
-									open={isCurrent}
-								>
-									<summary className="list-none flex gap-4 items-center cursor-pointer before:content-['▸'] before:text-2xl before:w-6 group-open:before:content-['▾']">
-										<Badge status={status} />
-										<h2 className="text-2xl">
-											Gate #{gate.gate} - {gate.pollsPerGate} polls
-										</h2>
-									</summary>
-									<div className="mt-2">
-										<p className="text-gray-400">
-											Score atleast: {formatGateRequirements(gate)}
-										</p>
-									</div>
-									<ol className="mt-3 space-y-1">
-										{getPollsForGate(
-											pollHistory,
-											gate.gate,
-											gate.pollsPerGate
-										).map((poll, idx) => (
-											<>
+							return displayGates.map((gate) => {
+								const status = getGateStatus(gate.gate, currentGate.gate);
+								const isCurrent = gate.gate === currentGate.gate;
+								const isVirtual = gate.gate > gates.length;
+
+								return (
+									<details
+										key={gate.gate}
+										className={`group border-b border-t border-white py-4 ${isCurrent ? "bg-white/5" : ""}`}
+										open={isCurrent}
+									>
+										<summary className="list-none flex gap-4 items-center cursor-pointer before:content-['▸'] before:text-2xl before:w-6 group-open:before:content-['▾']">
+											<Badge status={status} />
+											<h2 className="text-2xl">
+												Gate #{gate.gate} - {gate.pollsPerGate} polls
+												{isVirtual && (
+													<span className="ml-2 text-sm text-purple-400">
+														(Post-Victory)
+													</span>
+												)}
+											</h2>
+										</summary>
+										<div className="mt-2">
+											<p className="text-gray-400">
+												Score atleast: {formatGateRequirements(gate)}
+											</p>
+										</div>
+										<ol className="mt-3 space-y-1">
+											{getPollsForGate(
+												pollHistory,
+												gate.gate,
+												gate.pollsPerGate
+											).map((poll, idx) => (
 												<PollHistoryItem
 													key={poll.pollId}
 													poll={poll}
 													dailyPoll={dailyPoll.poll}
 													idx={idx + (gate.gate - 1) * gate.pollsPerGate}
 												/>
-											</>
-										))}
-									</ol>
-								</details>
-							);
-						})}
+											))}
+										</ol>
+									</details>
+								);
+							});
+						})()}
 					</div>
 					<CategoryCoverageGrid
 						categoryCoverage={activeRun.categoryCoverage}


### PR DESCRIPTION
Victory no longer ends the run. Instead, players enter "post-victory mode"
where they can continue playing daily polls to push for 100% coverage.

Changes:
- Add victory_achieved_at column to runs table
- Mark victory without ending run in processPollAnswer service
- Show victory banner in daily poll UI when in post-victory mode
- Update gate progress indicator to show completion status