### PR TITLE
feat: show refund amount on active config deinstall button

### DIFF
--- a/src/domains/configs/api/handlers.ts
+++ b/src/domains/configs/api/handlers.ts
@@ -1,5 +1,6 @@
 import { configs } from "~/domains/configs/data/configs";
 import { canAddConfigToRun } from "~/domains/economy/services/configManager.service";
+import { REFUND_RATE } from "~/lib/storage";
 import { getAuthenticatedUserId } from "~/utils/authorization";
 import { handleApiOperation } from "~/utils/errorHandling";
 
@@ -53,11 +54,10 @@ export const removeConfigFromRunHandler = async ({
 
 		// TODO: include other config effects in future if refundRate depends on them
 		// const { refundRate } = applyEffects(..., run.activeConfigIds);
-		const refundRate = 0.5;
 
 		// Get config cost before removing
 		const configToRemove = configs.find((c) => configIds.includes(c.id));
-		const penalty = (configToRemove?.cost ?? 0) * (1 - refundRate);
+		const penalty = (configToRemove?.cost ?? 0) * (1 - REFUND_RATE);
 
 		return await removeConfigFromRunQuery(runId, configIds, penalty, date);
 	});

--- a/src/domains/configs/components/Cards/ActiveCard.tsx
+++ b/src/domains/configs/components/Cards/ActiveCard.tsx
@@ -2,6 +2,7 @@ import { clsx } from "clsx";
 
 import ConfigCard, { RARITY_COLORS } from "~/domains/configs/components/Cards";
 import { Config } from "~/domains/configs/models/config";
+import { calculateRefund, formatStorage } from "~/lib/storage";
 
 type ActiveCardProps = {
 	config: Config;
@@ -26,16 +27,21 @@ const ActiveCard = ({
 		>
 			<ConfigCard config={config} disabled={disabled} size={size} />
 			{onDeinstall && (
-				<button
-					onClick={() => !disabled && onDeinstall(config)}
-					disabled={disabled}
-					className={clsx(
-						`border ${RARITY_COLORS[config.rarity].border} ${RARITY_COLORS[config.rarity].text} p-2 cursor-pointer`,
-						disabledStyles
-					)}
-				>
-					Deinstall
-				</button>
+				<div className="flex flex-col items-center">
+					<button
+						onClick={() => !disabled && onDeinstall(config)}
+						disabled={disabled}
+						className={clsx(
+							`border ${RARITY_COLORS[config.rarity].border} ${RARITY_COLORS[config.rarity].text} p-2 cursor-pointer w-full`,
+							disabledStyles
+						)}
+					>
+						Deinstall
+					</button>
+					<span className="text-celadon text-sm mt-1">
+						+{formatStorage(calculateRefund(config.cost))}
+					</span>
+				</div>
 			)}
 		</div>
 	);

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -11,6 +11,20 @@ export const STORAGE_UNITS = {
 } as const;
 
 /**
+ * Rate at which configs are refunded when deinstalled.
+ * Player gets back REFUND_RATE * cost, loses (1 - REFUND_RATE) * cost as penalty.
+ */
+export const REFUND_RATE = 0.5;
+
+/**
+ * Calculates the refund amount when deinstalling a config
+ * @param cost - Original config cost in bytes
+ * @returns Refund amount in bytes
+ */
+export const calculateRefund = (cost: number): number =>
+	Math.round(cost * REFUND_RATE);
+
+/**
  * Formats storage size in bytes to human-readable format
  * @param bytes - Storage size in bytes
  * @returns Formatted string (e.g., "1.5 MB", "512 KB")


### PR DESCRIPTION
- Add REFUND_RATE constant and calculateRefund helper to storage.ts
- Display "+{refund}" below Deinstall button for active configs
- Use shared REFUND_RATE in handlers.ts instead of hardcoded value

The refund amount (50% of config cost) is now shown to help players
understand how much storage they'll recover when deinstalling a config.