### PR TITLE
feat: move refund into deinstall button and add refund line to config card

### DIFF
--- a/src/domains/configs/components/Cards/ActiveCard.tsx
+++ b/src/domains/configs/components/Cards/ActiveCard.tsx
@@ -27,21 +27,16 @@ const ActiveCard = ({
 		>
 			<ConfigCard config={config} disabled={disabled} size={size} />
 			{onDeinstall && (
-				<div className="flex flex-col items-center">
-					<button
-						onClick={() => !disabled && onDeinstall(config)}
-						disabled={disabled}
-						className={clsx(
-							`border ${RARITY_COLORS[config.rarity].border} ${RARITY_COLORS[config.rarity].text} p-2 cursor-pointer w-full`,
-							disabledStyles
-						)}
-					>
-						Deinstall
-					</button>
-					<span className="text-celadon text-sm mt-1">
-						+{formatStorage(calculateRefund(config.cost))}
-					</span>
-				</div>
+				<button
+					onClick={() => !disabled && onDeinstall(config)}
+					disabled={disabled}
+					className={clsx(
+						`border ${RARITY_COLORS[config.rarity].border} ${RARITY_COLORS[config.rarity].text} p-2 cursor-pointer w-full`,
+						disabledStyles
+					)}
+				>
+					Deinstall (+{formatStorage(calculateRefund(config.cost))})
+				</button>
 			)}
 		</div>
 	);

--- a/src/domains/configs/components/Cards/index.tsx
+++ b/src/domains/configs/components/Cards/index.tsx
@@ -1,7 +1,7 @@
 import { clsx } from "clsx";
 
 import { Config } from "~/domains/configs/models/config";
-import { formatStorage } from "~/lib/storage";
+import { calculateRefund, formatStorage } from "~/lib/storage";
 
 export const RARITY_COLORS = {
 	common: {
@@ -59,6 +59,7 @@ const ConfigCard = ({ config, disabled, size = "large" }: ConfigProps) => {
 		>
 			<h3 className={clsx("text-2xl", rarityColor.text)}>{config.name}</h3>
 			<p>Cost: {formatStorage(config.cost)}</p>
+			<p>Refund: {formatStorage(calculateRefund(config.cost))}</p>
 			<p>
 				Rarity: <span className={rarityColor.text}>{config.rarity}</span>
 			</p>


### PR DESCRIPTION
Move the refund amount display inside the deinstall button for cleaner UI.
Also add a "Refund" line below "Cost" in the config card details.