### PR TITLE
feat: add My Polls link to navigation

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -170,6 +170,16 @@ function Navigation() {
 						>
 							Suggest your own poll
 						</Link>
+						<span className="text-white">·</span>
+						<Link
+							to="/polls"
+							activeProps={{
+								className: "underline",
+							}}
+							activeOptions={{ exact: true }}
+						>
+							My Polls
+						</Link>
 						<div className="ml-auto flex gap-2 items-center">
 							<Link
 								to="/profile/$userId"


### PR DESCRIPTION
Add a link to /polls in the main navigation for logged-in users.
The polls page already handles authorization correctly - admins see
all polls while regular users only see their own poll submissions.