### PR TITLE
fix: apply category theme colors to poll filter buttons

### DIFF
--- a/src/routes/_authed/polls/index.tsx
+++ b/src/routes/_authed/polls/index.tsx
@@ -140,7 +140,7 @@ function PollsList() {
 							className={`px-3 py-1 rounded-full text-sm transition-colors ${
 								isSelected
 									? isCategory
-										? "bg-theme text-black"
+										? "bg-theme text-white"
 										: "bg-primary text-white"
 									: "bg-gray-700 text-gray-300 hover:bg-gray-600"
 							}`}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -223,16 +223,20 @@
 /* Category-based theme utilities */
 /* HTML category */
 [data-category-theme="html"] {
-	.text-theme {
+	.text-theme,
+	&.text-theme {
 		color: var(--color-vermillion);
 	}
-	.bg-theme {
+	.bg-theme,
+	&.bg-theme {
 		background-color: var(--color-vermillion);
 	}
-	.border-theme {
+	.border-theme,
+	&.border-theme {
 		border-color: var(--color-vermillion);
 	}
-	.accent-theme {
+	.accent-theme,
+	&.accent-theme {
 		accent-color: var(--color-vermillion);
 	}
 	--meter-fill: var(--color-vermillion);
@@ -241,16 +245,20 @@
 
 /* CSS category */
 [data-category-theme="css"] {
-	.text-theme {
+	.text-theme,
+	&.text-theme {
 		color: var(--color-cerulean);
 	}
-	.bg-theme {
+	.bg-theme,
+	&.bg-theme {
 		background-color: var(--color-cerulean);
 	}
-	.border-theme {
+	.border-theme,
+	&.border-theme {
 		border-color: var(--color-cerulean);
 	}
-	.accent-theme {
+	.accent-theme,
+	&.accent-theme {
 		accent-color: var(--color-cerulean);
 	}
 	--meter-fill: var(--color-cerulean);
@@ -259,16 +267,20 @@
 
 /* JavaScript category */
 [data-category-theme="js"] {
-	.text-theme {
+	.text-theme,
+	&.text-theme {
 		color: var(--color-saffron);
 	}
-	.bg-theme {
+	.bg-theme,
+	&.bg-theme {
 		background-color: var(--color-saffron);
 	}
-	.border-theme {
+	.border-theme,
+	&.border-theme {
 		border-color: var(--color-saffron);
 	}
-	.accent-theme {
+	.accent-theme,
+	&.accent-theme {
 		accent-color: var(--color-saffron);
 	}
 	--meter-fill: var(--color-saffron);
@@ -277,16 +289,20 @@
 
 /* TypeScript category */
 [data-category-theme="ts"] {
-	.text-theme {
+	.text-theme,
+	&.text-theme {
 		color: var(--color-lavender);
 	}
-	.bg-theme {
+	.bg-theme,
+	&.bg-theme {
 		background-color: var(--color-lavender);
 	}
-	.border-theme {
+	.border-theme,
+	&.border-theme {
 		border-color: var(--color-lavender);
 	}
-	.accent-theme {
+	.accent-theme,
+	&.accent-theme {
 		accent-color: var(--color-lavender);
 	}
 	--meter-fill: var(--color-lavender);
@@ -295,16 +311,20 @@
 
 /* General Frontend category */
 [data-category-theme="general-frontend"] {
-	.text-theme {
+	.text-theme,
+	&.text-theme {
 		color: var(--color-fuchsia);
 	}
-	.bg-theme {
+	.bg-theme,
+	&.bg-theme {
 		background-color: var(--color-fuchsia);
 	}
-	.border-theme {
+	.border-theme,
+	&.border-theme {
 		border-color: var(--color-fuchsia);
 	}
-	.accent-theme {
+	.accent-theme,
+	&.accent-theme {
 		accent-color: var(--color-fuchsia);
 	}
 	--meter-fill: var(--color-fuchsia);
@@ -313,16 +333,20 @@
 
 /* React category */
 [data-category-theme="react"] {
-	.text-theme {
+	.text-theme,
+	&.text-theme {
 		color: var(--color-celadon);
 	}
-	.bg-theme {
+	.bg-theme,
+	&.bg-theme {
 		background-color: var(--color-celadon);
 	}
-	.border-theme {
+	.border-theme,
+	&.border-theme {
 		border-color: var(--color-celadon);
 	}
-	.accent-theme {
+	.accent-theme,
+	&.accent-theme {
 		accent-color: var(--color-celadon);
 	}
 	--meter-fill: var(--color-celadon);
@@ -331,50 +355,64 @@
 
 /* Git category */
 [data-category-theme="git"] {
-	.text-theme {
+	.text-theme,
+	&.text-theme {
 		color: var(--color-pewter);
 	}
-	.bg-theme {
+	.bg-theme,
+	&.bg-theme {
 		background-color: var(--color-pewter);
 	}
-	.border-theme {
+	.border-theme,
+	&.border-theme {
 		border-color: var(--color-pewter);
 	}
-	.accent-theme {
+	.accent-theme,
+	&.accent-theme {
 		accent-color: var(--color-pewter);
 	}
 	--meter-fill: var(--color-pewter);
 	--meter-bg: oklch(from var(--color-pewter) calc(l - 0.25) c h);
 }
 
+/* Java category */
 [data-category-theme="java"] {
-	.text-theme {
+	.text-theme,
+	&.text-theme {
 		color: var(--color-indigo);
 	}
-	.bg-theme {
+	.bg-theme,
+	&.bg-theme {
 		background-color: var(--color-indigo);
 	}
-	.border-theme {
+	.border-theme,
+	&.border-theme {
 		border-color: var(--color-indigo);
 	}
-	.accent-theme {
+	.accent-theme,
+	&.accent-theme {
 		accent-color: var(--color-indigo);
 	}
 	--meter-fill: var(--color-indigo);
 	--meter-bg: oklch(from var(--color-indigo) calc(l - 0.25) c h);
 }
 
+/* Python category */
 [data-category-theme="python"] {
-	.text-theme {
+	.text-theme,
+	&.text-theme {
 		color: var(--color-viridian);
 	}
-	.bg-theme {
+	.bg-theme,
+	&.bg-theme {
 		background-color: var(--color-viridian);
 	}
-	.border-theme {
+	.border-theme,
+	&.border-theme {
 		border-color: var(--color-viridian);
 	}
-	.accent-theme {
+	.accent-theme,
+	&.accent-theme {
 		accent-color: var(--color-viridian);
 	}
 	--meter-fill: var(--color-viridian);


### PR DESCRIPTION
- Add same-element selectors (&.bg-theme, &.text-theme, etc.) to CSS
  category themes so colors apply when data-category-theme and the
  theme class are on the same element
- Change selected button text from black to white for visibility
  on dark category colors (indigo, pewter, lavender, etc.)