### PR TITLE
feat: add last updated timestamp to footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,9 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
+import { format } from "date-fns";
 
 import { configs } from "~/domains/configs/data/configs";
 import { getAllPolls } from "~/domains/polls/api/polls";
 import { getCategories } from "~/domains/shared/categories";
+
+declare const __LAST_COMMIT_DATE__: string;
 
 const Footer = () => {
 	const { data, error, isLoading } = useQuery({
@@ -32,7 +35,8 @@ const Footer = () => {
 			<section className="">
 				<p>
 					A crazy roguelike obsession build with craftsmanship, passion, ❤️ &
-					Tanstack Start by Marciano Schildmeijer | EST may 2022
+					Tanstack Start by Marciano Schildmeijer | EST may 2022 | Last updated:{" "}
+					{format(new Date(__LAST_COMMIT_DATE__), "d MMM yyyy")}
 				</p>
 				<p className="mt-2 text-zinc-400">
 					Found a bug?{" "}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,10 +5,22 @@ import { resolve } from "path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { nitro } from "nitro/vite";
+import { execSync } from "child_process";
+
+const getLastCommitDate = () => {
+	try {
+		return execSync("git log -1 --format=%cI").toString().trim();
+	} catch {
+		return new Date().toISOString();
+	}
+};
 
 export default defineConfig(({ mode }) => ({
 	server: {
 		port: 3005,
+	},
+	define: {
+		__LAST_COMMIT_DATE__: JSON.stringify(getLastCommitDate()),
 	},
 	resolve: {
 		alias: [


### PR DESCRIPTION
Display the date of the last git commit in the footer, formatted as
"d MMM yyyy" (e.g., "10 Jan 2026"). The commit date is captured at
build time via Vite's define config.