### PR TITLE
Add Slackbot daily reminder with link

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,3 +16,12 @@ VITE_SUPABASE_ANON_KEY=your-anon-key
 
 NODE_ENV=development
 SONAR_TOKEN=your-sonar-token
+
+# Slack Integration
+
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+APP_URL=https://devvoted.com
+
+# Cron Security (optional - for securing cron endpoints)
+
+CRON_SECRET=your-random-secret-string

--- a/server/api/cron/daily-reminder.ts
+++ b/server/api/cron/daily-reminder.ts
@@ -1,0 +1,30 @@
+import { defineEventHandler, getHeader, createError } from "nitro/runtime";
+import { sendDailyReminder } from "../../../src/domains/notifications/services/slack.service";
+
+export default defineEventHandler(async (event) => {
+	// Verify the request is from Vercel Cron (optional but recommended)
+	const authHeader = getHeader(event, "authorization");
+	const cronSecret = process.env.CRON_SECRET;
+
+	if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+		throw createError({ statusCode: 401, message: "Unauthorized" });
+	}
+
+	try {
+		await sendDailyReminder();
+
+		return {
+			success: true,
+			message: "Daily reminder sent successfully",
+			timestamp: new Date().toISOString(),
+		};
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		console.error("Failed to send daily reminder:", message);
+
+		throw createError({
+			statusCode: 500,
+			message: `Failed to send daily reminder: ${message}`,
+		});
+	}
+});

--- a/src/domains/notifications/services/slack.service.ts
+++ b/src/domains/notifications/services/slack.service.ts
@@ -1,0 +1,100 @@
+type SlackBlock =
+	| {
+			type: "section";
+			text: {
+				type: "mrkdwn" | "plain_text";
+				text: string;
+			};
+	  }
+	| {
+			type: "divider";
+	  }
+	| {
+			type: "actions";
+			elements: Array<{
+				type: "button";
+				text: {
+					type: "plain_text";
+					text: string;
+					emoji?: boolean;
+				};
+				url?: string;
+				style?: "primary" | "danger";
+			}>;
+	  };
+
+type SlackMessage = {
+	text: string;
+	blocks?: SlackBlock[];
+};
+
+const getWebhookUrl = (): string => {
+	const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+
+	if (!webhookUrl) {
+		throw new Error("SLACK_WEBHOOK_URL environment variable is not set");
+	}
+
+	return webhookUrl;
+};
+
+export const sendSlackMessage = async (message: SlackMessage): Promise<void> => {
+	const webhookUrl = getWebhookUrl();
+
+	const response = await fetch(webhookUrl, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(message),
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw new Error(`Failed to send Slack message: ${response.status} - ${errorText}`);
+	}
+};
+
+export const sendDailyReminder = async (): Promise<void> => {
+	const appUrl = process.env.APP_URL || "https://devvoted.com";
+
+	const message: SlackMessage = {
+		text: "Time to test your developer knowledge! Today's DevVoted quiz is ready.",
+		blocks: [
+			{
+				type: "section",
+				text: {
+					type: "mrkdwn",
+					text: "*Daily DevVoted Reminder*",
+				},
+			},
+			{
+				type: "divider",
+			},
+			{
+				type: "section",
+				text: {
+					type: "mrkdwn",
+					text: "A new day, a new challenge! Test your developer knowledge and climb the leaderboard.",
+				},
+			},
+			{
+				type: "actions",
+				elements: [
+					{
+						type: "button",
+						text: {
+							type: "plain_text",
+							text: "Play Now",
+							emoji: true,
+						},
+						url: appUrl,
+						style: "primary",
+					},
+				],
+			},
+		],
+	};
+
+	await sendSlackMessage(message);
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,11 @@
 {
 	"buildCommand": "npm run build",
 	"installCommand": "npm ci --include=optional",
-	"framework": null
+	"framework": null,
+	"crons": [
+		{
+			"path": "/api/cron/daily-reminder",
+			"schedule": "0 9 * * *"
+		}
+	]
 }


### PR DESCRIPTION
Add a Slackbot that sends daily reminders with a link to play DevVoted. Uses Vercel Cron to trigger at 9 AM UTC daily.

- Add Slack notification service with webhook support
- Create API endpoint for cron-triggered daily reminders
- Configure Vercel Cron schedule
- Add environment variables for Slack integration