### PR TITLE
feat: UI layer refactor foundation (Phases 1 & 2)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,6 +2,8 @@
 
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_ANON_KEY=your-anon-key
+# Required for db:seed to create the local dev auth user (run: npx supabase status)
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # Database
 

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ polls-d8b3d-firebase-adminsdk-cos71-910d48b66d.json
 scripts/firebase-service-account.json
 firebase-backup*
 firebase-polls-backup-*.json
+storybook-static/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 # Keep environment variables out of version control
 !.env
 yarn.lock
+.yarn/
 
 .DS_Store
 .cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 node_modules
 # Keep environment variables out of version control
 !.env
-yarn.lock
-.yarn/
 
 .DS_Store
 .cache

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -126,7 +126,6 @@
 		"import/no-named-as-default-member": "warn",
 		"import/no-duplicates": "warn",
 		"@typescript-eslint/no-explicit-any": "off",
-		"react/prop-types": "off",
 		"no-console": [
 			"warn",
 			{

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -3,10 +3,7 @@ import tailwindcss from "@tailwindcss/vite";
 import tsConfigPaths from "vite-tsconfig-paths";
 
 const config: StorybookConfig = {
-	stories: [
-		"../src/ui/**/*.stories.@(ts|tsx)",
-		"../src/domains/**/ui/**/*.stories.@(ts|tsx)",
-	],
+	stories: ["../src/ui/**/*.stories.@(ts|tsx)"],
 	addons: ["@storybook/addon-themes"],
 	framework: {
 		name: "@storybook/react-vite",

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,23 @@
+import type { StorybookConfig } from "@storybook/react-vite";
+import tailwindcss from "@tailwindcss/vite";
+import tsConfigPaths from "vite-tsconfig-paths";
+
+const config: StorybookConfig = {
+	stories: [
+		"../src/ui/**/*.stories.@(ts|tsx)",
+		"../src/domains/**/ui/**/*.stories.@(ts|tsx)",
+	],
+	addons: ["@storybook/addon-themes"],
+	framework: {
+		name: "@storybook/react-vite",
+		options: {},
+	},
+	viteFinal: (config) => {
+		config.plugins = config.plugins ?? [];
+		config.plugins.push(tsConfigPaths());
+		config.plugins.push(tailwindcss());
+		return config;
+	},
+};
+
+export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,20 @@
+import type { Preview } from "@storybook/react";
+import { withThemeByClassName } from "@storybook/addon-themes";
+import "../src/styles/app.css";
+
+const preview: Preview = {
+	decorators: [
+		withThemeByClassName({
+			themes: {
+				dark: "dark",
+				light: "",
+			},
+			defaultTheme: "dark",
+		}),
+	],
+	parameters: {
+		backgrounds: { disable: true },
+	},
+};
+
+export default preview;

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,0 @@
-nodeLinker: node-modules

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,9 +91,9 @@ src/domains/{domain}/
 | Location | Purpose |
 |----------|---------|
 | `src/ui/` | Pure presentational primitives (buttons, skeletons) - no business logic, no data fetching |
-| `src/domains/*/ui/` | Domain-specific presentational components - compose `src/ui/` primitives, no data fetching or state |
+| `src/ui/{domain}/` | Domain-specific presentational components - compose `src/ui/` primitives, no data fetching or state |
 | `src/components/` | Global shared components with logic (layouts, auth, navigation) |
-| `src/domains/*/components/` | Domain composition layer - wires data and logic to domain UI components, no HTML/CSS |
+| `src/domains/*/components/` | Domain composition layer - wires data and logic to UI components, no HTML/CSS |
 | `src/routes/` | Route composition layer - wires loader data and mutations to components, no HTML/CSS |
 
 ### UI Layer Architecture (CRITICAL)
@@ -102,10 +102,12 @@ The app enforces a strict two-tier UI separation to keep all visual code indepen
 
 **Tier 1 — Presentational (design system)**
 - `src/ui/` — global primitives: `Button`, `Card`, `Badge`, `Skeleton`, etc.
-- `src/domains/*/ui/` — domain-specific visuals: `PollCard`, `RunHeader`, `UpgradeCardSlot`, etc.
+- `src/ui/{domain}/` — domain-specific visuals: `src/ui/polls/PollCard.ui.tsx`, `src/ui/runs/RunHeader.ui.tsx`, etc.
 - These files contain **all HTML tags and Tailwind CSS classes** in the codebase.
 - They accept only plain data props (no hooks, no server functions, no TanStack Query).
 - They are fully renderable from mock factory data in Storybook without a running server.
+
+`src/domains/` is the application and business logic layer. It must not contain any UI (React components, HTML, CSS). Domain-specific UI belongs in `src/ui/{domain}/` so the domain stays portable across interfaces (CLI, API, web).
 
 **Tier 2 — Composition (app layer)**
 - `src/domains/*/components/` — domain smart components
@@ -122,7 +124,7 @@ export const PollSection = ({ poll }: { poll: Poll }) => (
 );
 
 // ✅ CORRECT: domain component is pure composition
-// src/domains/polls/ui/PollSection.ui.tsx  ← owns the HTML/CSS
+// src/ui/polls/PollSection.ui.tsx  ← owns the HTML/CSS
 export const PollSection = ({ question }: { question: string }) => (
   <div className="flex flex-col gap-4 p-6 rounded-xl bg-surface">
     <h2 className="text-lg font-bold">{question}</h2>
@@ -139,11 +141,11 @@ export const PollSection = () => {
 
 **File naming conventions:**
 - `src/ui/Button.component.tsx` — global primitive
-- `src/domains/{domain}/ui/PollCard.ui.tsx` — domain UI component
+- `src/ui/{domain}/PollCard.ui.tsx` — domain-scoped UI component
 - `src/domains/{domain}/components/PollSection.component.tsx` — domain composition component
 
 **Rules enforced on every new file:**
-- [ ] Does this file render HTML or use Tailwind classes? → It belongs in `src/ui/` or `src/domains/*/ui/`, receives only plain props, has a Story.
+- [ ] Does this file render HTML or use Tailwind classes? → It belongs in `src/ui/` (or `src/ui/{domain}/`), receives only plain props, has a Story.
 - [ ] Does this file call a hook, query, or server function? → It belongs in `src/domains/*/components/` or `src/routes/`, contains zero HTML/CSS.
 - [ ] Never mix both in the same file.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,9 +90,62 @@ src/domains/{domain}/
 
 | Location | Purpose |
 |----------|---------|
-| `src/ui/` | Pure presentational primitives (buttons, skeletons) - no business logic |
+| `src/ui/` | Pure presentational primitives (buttons, skeletons) - no business logic, no data fetching |
+| `src/domains/*/ui/` | Domain-specific presentational components - compose `src/ui/` primitives, no data fetching or state |
 | `src/components/` | Global shared components with logic (layouts, auth, navigation) |
-| `src/domains/*/components/` | Domain-specific components |
+| `src/domains/*/components/` | Domain composition layer - wires data and logic to domain UI components, no HTML/CSS |
+| `src/routes/` | Route composition layer - wires loader data and mutations to components, no HTML/CSS |
+
+### UI Layer Architecture (CRITICAL)
+
+The app enforces a strict two-tier UI separation to keep all visual code independently testable in Storybook:
+
+**Tier 1 — Presentational (design system)**
+- `src/ui/` — global primitives: `Button`, `Card`, `Badge`, `Skeleton`, etc.
+- `src/domains/*/ui/` — domain-specific visuals: `PollCard`, `RunHeader`, `UpgradeCardSlot`, etc.
+- These files contain **all HTML tags and Tailwind CSS classes** in the codebase.
+- They accept only plain data props (no hooks, no server functions, no TanStack Query).
+- They are fully renderable from mock factory data in Storybook without a running server.
+
+**Tier 2 — Composition (app layer)**
+- `src/domains/*/components/` — domain smart components
+- `src/routes/` — route files
+- These files contain **zero HTML tags and zero CSS classes**.
+- Their only job is: read data (from loader, hook, or query), call mutations, and pass results as props to Tier 1 components.
+
+```tsx
+// ❌ WRONG: HTML/CSS in a domain component
+export const PollSection = ({ poll }: { poll: Poll }) => (
+  <div className="flex flex-col gap-4 p-6 rounded-xl bg-surface">
+    <h2 className="text-lg font-bold">{poll.question}</h2>
+  </div>
+);
+
+// ✅ CORRECT: domain component is pure composition
+// src/domains/polls/ui/PollSection.ui.tsx  ← owns the HTML/CSS
+export const PollSection = ({ question }: { question: string }) => (
+  <div className="flex flex-col gap-4 p-6 rounded-xl bg-surface">
+    <h2 className="text-lg font-bold">{question}</h2>
+  </div>
+);
+
+// src/domains/polls/components/PollSection.component.tsx  ← owns the wiring
+export const PollSection = () => {
+  const { poll } = Route.useLoaderData();
+  const submit = useSubmitPoll();
+  return <PollSectionUI question={poll.question} onSubmit={submit} />;
+};
+```
+
+**File naming conventions:**
+- `src/ui/Button.component.tsx` — global primitive
+- `src/domains/{domain}/ui/PollCard.ui.tsx` — domain UI component
+- `src/domains/{domain}/components/PollSection.component.tsx` — domain composition component
+
+**Rules enforced on every new file:**
+- [ ] Does this file render HTML or use Tailwind classes? → It belongs in `src/ui/` or `src/domains/*/ui/`, receives only plain props, has a Story.
+- [ ] Does this file call a hook, query, or server function? → It belongs in `src/domains/*/components/` or `src/routes/`, contains zero HTML/CSS.
+- [ ] Never mix both in the same file.
 
 ### Key Database Tables
 

--- a/docs/ui-layer-refactor-plan.md
+++ b/docs/ui-layer-refactor-plan.md
@@ -1,6 +1,8 @@
 # UI Layer Refactor Plan
 
-**Goal:** Enforce strict two-tier UI separation across the codebase so that all HTML/CSS lives in presentational components (`src/ui/` and `src/domains/*/ui/`) and all composition lives in smart components (`src/domains/*/components/` and `src/routes/`). This makes the entire visual layer independently renderable in Storybook.
+**Goal:** Enforce strict two-tier UI separation across the codebase so that all HTML/CSS lives in presentational components under `src/ui/` and all composition lives in smart components (`src/domains/*/components/` and `src/routes/`). This makes the entire visual layer independently renderable in Storybook.
+
+**Architectural principle:** `src/domains/` is the business logic and application layer — it must contain no UI. Domain-specific presentational components live in `src/ui/{domain}/` (e.g. `src/ui/polls/`, `src/ui/runs/`). This keeps domains portable across interfaces (CLI, API, web).
 
 See CLAUDE.md § "UI Layer Architecture" for the enforced rules.
 
@@ -13,7 +15,6 @@ Three layers of protection, introduced in order of when they become safe to enab
 | Layer | What it catches | When to add |
 |-------|----------------|-------------|
 | Testing Library unit tests | Rendering regressions in UI components | As part of each extraction phase |
-| Chromatic visual snapshots | Visual/style regressions across all stories | After Phase 1 (Storybook has stories) |
 | ESLint architectural rule | New violations of the two-tier rule | **After Phase 7** (migration complete — would fail CI on all existing violations if added earlier) |
 
 The ESLint rule is the most powerful long-term guard but would block every PR until migration is complete, so it is deliberately the last step.
@@ -26,70 +27,44 @@ Each phase is independently shippable and leaves the app fully working. Later ph
 
 ---
 
-## Phase 1 — Foundation
+## Phase 1 — Foundation ✅
 
-### 1.1 Install and configure Storybook
+### 1.1 Install and configure Storybook ✅
 
-- Add Storybook with the Vite + React + Tailwind preset
-- Point it at `src/ui/**/*.stories.tsx` and `src/domains/**/ui/**/*.stories.tsx`
-- Confirm Tailwind v4 classes render correctly inside Storybook
-- Add `npm run storybook` to CLAUDE.md Common Commands
+- Storybook 10 with Vite + React + Tailwind v4
+- Points at `src/ui/**/*.stories.tsx` and `src/ui/**/**/*.stories.tsx`
+- Dark mode by default with toolbar toggle
+- `npm run storybook` starts on port 6006
 
-### 1.2 Write stories for existing `src/ui/` primitives
+### 1.2 Write stories and unit tests for existing `src/ui/` primitives ✅
 
-For each existing primitive, write a `.stories.tsx` file next to it:
+Stories and tests written for:
 - `PrimaryButton`, `SecondaryButton`, `TextButton`
 - `LoadingSkeleton`
-- `Dropdown`, `Popover`
+- `Dropdown`, `DropdownItem`, `DropdownDivider`
+- `Popover`
 - `ConfirmDialog`
-- `ErrorComponent`
 
-This validates the Storybook setup and documents the current primitive API.
+### 1.3 Scaffold `src/ui/{domain}/` directories ✅
 
-### 1.3 Write Testing Library unit tests for existing `src/ui/` primitives
-
-For each primitive, write a `.spec.tsx` file next to it that:
-- Renders the component with representative props (seeded from the same mock data used in stories)
-- Asserts on visible output (text, ARIA roles, disabled state) — not on CSS classes
-- Covers any conditional rendering branches
-
-These tests run in CI from day one and establish the baseline before any refactoring.
-
-### 1.4 Set up Chromatic
-
-- Connect the repository to Chromatic
-- Add `chromatic --project-token=...` as a CI step after Storybook build
-- Accept the initial baseline snapshots from step 1.2
-- From this point on, every PR that changes a story shows a visual diff
-
-### 1.5 Create `src/domains/*/ui/` directories
-
-Create the `ui/` subdirectory inside each domain that has components:
-- `src/domains/polls/ui/`
-- `src/domains/runs/ui/`
-- `src/domains/economy/ui/`
-- `src/domains/ranking/ui/`
-
-No files yet — just the scaffolding so the pattern is visible.
+- `src/ui/polls/`
+- `src/ui/runs/`
+- `src/ui/economy/`
+- `src/ui/ranking/`
 
 ---
 
-## Phase 2 — Global shared components
+## Phase 2 — Global shared components ✅
 
 **Target:** `src/components/` (layouts, navigation, auth).
 
-These are the most reused components. Splitting them first proves the pattern at low risk.
-
-For each component in `src/components/`:
-1. Extract all HTML/CSS into a sibling `src/ui/` primitive (or a new `src/components/ui/` if it is layout-only).
-2. Reduce the original file to a pure composition component that calls hooks/context and passes props.
-3. Write a Storybook story for the extracted primitive.
-4. Write a Testing Library unit test for the extracted primitive.
-
-Key targets:
-- Navigation/header components
-- Layout wrappers
-- Auth guard wrappers (the guard logic stays in the component; only the rendered chrome moves to UI)
+Extracted primitives (all with `.stories.tsx` and `.spec.tsx`):
+- `ContentSection` — `<section>` with category theme attribute
+- `PageLayoutUI` — `<main>` shell with footer slot
+- `FooterUI` — stats footer with configurable link slot
+- `NotFoundUI` — 404 page with back button and home link slot
+- `CatchBoundaryUI` — error boundary UI with retry button and navigation slot
+- `DevPollNavigatorUI` — dev-only poll navigator
 
 ---
 
@@ -98,12 +73,12 @@ Key targets:
 Economy is the cleanest domain. `useArchiveState` already abstracts state correctly; `BorderShop.component.tsx` is close to correct. This makes it the lowest-effort domain to demonstrate the full pattern end-to-end.
 
 ### Steps
-1. Create `src/domains/economy/ui/BorderShopUI.ui.tsx` — extract all HTML/CSS from `BorderShop.component.tsx` into a pure props component.
+1. Create `src/ui/economy/BorderShopUI.ui.tsx` — extract all HTML/CSS from `BorderShop.component.tsx` into a pure props component.
 2. Reduce `BorderShop.component.tsx` to call `useArchiveState` and pass results to `BorderShopUI`.
 3. Write `BorderShopUI.stories.tsx` seeded with `createMockArchiveState`.
 4. Write `BorderShopUI.spec.tsx` — renders with mock props, asserts on visible output.
-5. Repeat for `ShopContainer`: extract `ShopContainerUI`, write story and unit test.
-6. Extract inline mutations from `ShopContainer` into `useInstallConfig`, `useRerollShop`, `useSkipShop` hooks (from the analysis: medium-severity violation).
+5. Repeat for `ShopContainer`: extract `src/ui/economy/ShopContainerUI.ui.tsx`, write story and unit test.
+6. Extract inline mutations from `ShopContainer` into `useInstallConfig`, `useRerollShop`, `useSkipShop` hooks.
 
 ---
 
@@ -113,7 +88,7 @@ Economy is the cleanest domain. `useArchiveState` already abstracts state correc
 1. Move `createServerFn` out of `useCurrentSeason.hook.ts` → `src/domains/ranking/api/ranking.ts`.
 2. Register leaderboard query key in `src/domains/shared/queryKeys.ts`.
 3. Extract `useLeaderboard(categoryCode)` hook from `Leaderboard.component.tsx`.
-4. Create `src/domains/ranking/ui/LeaderboardUI.ui.tsx` — extract all HTML/CSS, add story and unit test.
+4. Create `src/ui/ranking/LeaderboardUI.ui.tsx` — extract all HTML/CSS, add story and unit test.
 5. Reduce `Leaderboard.component.tsx` to composition only.
 
 ---
@@ -123,7 +98,7 @@ Economy is the cleanest domain. `useArchiveState` already abstracts state correc
 The runs domain already has good mutation hooks. The main work is visual extraction.
 
 ### Steps
-1. Create `ui/` components for each existing domain component (e.g. `RunHeaderUI`, `UpgradeCardUI`, `PipelineSectionUI`).
+1. Create `src/ui/runs/` components for each existing domain component (e.g. `RunHeaderUI`, `UpgradeCardUI`, `PipelineSectionUI`).
 2. Write stories and unit tests for each, seeded from existing mock factories.
 3. Reduce each `*.component.tsx` to composition only.
 
@@ -136,17 +111,17 @@ This domain has the most violations. Tackle in this order to avoid cascading bre
 ### 6.1 Move server functions out of component files
 - Move `getScoreBreakdown`, `getCommunityStats`, `getRandomAnswer` from `DailyPollContainer.component.tsx` → `src/domains/polls/api/polls.ts`
 - Move `getCategoryWeights` from `CategoryWeightsDisplay.component.tsx` → `src/domains/polls/api/polls.ts`
-- Update all import sites (`daily-poll/index.tsx`, etc.)
+- Update all import sites
 
 ### 6.2 Extract hooks
-- `useSubmitDailyPoll` — owns the primary mutation, the five post-answer state values, query invalidation, and navigation. Extracted from `DailyPollContainer`.
-- `useDeinstallConfig` — shared hook consumed by both `DailyPollContainer` and `progress.tsx` (eliminates the duplication identified in the analysis).
+- `useSubmitDailyPoll` — owns the primary mutation, post-answer state values, query invalidation, and navigation.
+- `useDeinstallConfig` — shared hook consumed by both `DailyPollContainer` and `progress.tsx`.
 - `useCategoryWeights` — wraps the query for `CategoryWeightsDisplay`.
 
-### 6.3 Extract UI components, write stories and unit tests
-- `DailyPollContainerUI` — receives score, upgrade cards, evaluation context, submission handler as props.
-- `CategoryWeightsDisplayUI` — receives `{ category: string; percentage: number }[]` as a prop.
-- `PollOptionsFormUI` — the form is already close; extract the remaining HTML.
+### 6.3 Extract UI components into `src/ui/polls/`, write stories and unit tests
+- `src/ui/polls/DailyPollContainerUI.ui.tsx` — receives score, upgrade cards, evaluation context, submission handler as props.
+- `src/ui/polls/CategoryWeightsDisplayUI.ui.tsx` — receives `{ category: string; percentage: number }[]` as a prop.
+- `src/ui/polls/PollOptionsFormUI.ui.tsx` — the form shell with remaining HTML.
 
 ### 6.4 Reduce component files to composition only
 
@@ -154,13 +129,13 @@ This domain has the most violations. Tackle in this order to avoid cascading bre
 
 ## Phase 7 — Routes (`src/routes/`)
 
-By this phase all domain UI is in `ui/` components. Routes only need to:
+By this phase all domain UI is in `src/ui/{domain}/` components. Routes only need to:
 1. Read loader data.
-2. Call domain composition components or (for simple cases) domain UI components directly.
+2. Call domain composition components or (for simple cases) UI components directly.
 3. Contain zero HTML/CSS themselves.
 
-Key route files to clean up (identified in analysis):
-- `src/routes/_authed/admin.tsx` — move 4 server functions + Drizzle queries to `src/domains/ranking/api/` and an admin handler; convert manual loading state to TanStack Query mutations; extract `AdminPanelUI`.
+Key route files to clean up:
+- `src/routes/_authed/admin.tsx` — move server functions + Drizzle queries to `src/domains/ranking/api/`; extract `src/ui/admin/AdminPanelUI.ui.tsx`.
 - `src/routes/start.tsx` — extract `useStartRun` hook for the inline mutation.
 - `src/routes/_authed/progress.tsx` — use shared `useDeinstallConfig` hook (from Phase 6.2).
 - `src/routes/stats.tsx` — move `computeRunStats` to `src/domains/runs/utils/runStats.ts`.
@@ -169,22 +144,21 @@ Key route files to clean up (identified in analysis):
 
 ## Phase 8 — Enforce via ESLint
 
-**Only add this after Phase 7 is complete.** At that point there are zero existing violations, so the rule becomes a pure guard against regression rather than a source of CI failures.
+**Only add this after Phase 7 is complete.** At that point there are zero existing violations, so the rule becomes a pure guard against regression.
 
 Add an ESLint rule (or a custom script) that:
 - Flags any file in `src/routes/` or `src/domains/*/components/` that contains an HTML tag or a Tailwind class string.
-- Flags any file in `src/ui/` or `src/domains/*/ui/` that imports from `@tanstack/react-query`, `@tanstack/react-router`, or `~/domains/*/api/`.
-
-This makes the architectural constraint machine-checkable so it cannot regress silently.
+- Flags any file in `src/ui/` that imports from `@tanstack/react-query`, `@tanstack/react-router`, or `~/domains/*/api/`.
+- Flags any file in `src/domains/` that contains JSX or imports React.
 
 ---
 
 ## Definition of Done (per phase)
 
-- [ ] All HTML/CSS for the scope is in `src/ui/` or `src/domains/*/ui/` files
+- [ ] All HTML/CSS for the scope is in `src/ui/` or `src/ui/{domain}/` files
 - [ ] Every extracted UI component has a Storybook story seeded from a mock factory
 - [ ] Every extracted UI component has a Testing Library unit test asserting on visible output
-- [ ] Chromatic accepts the new/changed snapshots
 - [ ] Composition components in scope contain zero HTML tags and zero Tailwind classes
+- [ ] `src/domains/` files in scope contain no JSX or React imports
 - [ ] `npm run build` passes
 - [ ] `npm test` passes

--- a/docs/ui-layer-refactor-plan.md
+++ b/docs/ui-layer-refactor-plan.md
@@ -1,0 +1,190 @@
+# UI Layer Refactor Plan
+
+**Goal:** Enforce strict two-tier UI separation across the codebase so that all HTML/CSS lives in presentational components (`src/ui/` and `src/domains/*/ui/`) and all composition lives in smart components (`src/domains/*/components/` and `src/routes/`). This makes the entire visual layer independently renderable in Storybook.
+
+See CLAUDE.md § "UI Layer Architecture" for the enforced rules.
+
+---
+
+## Regression prevention strategy
+
+Three layers of protection, introduced in order of when they become safe to enable:
+
+| Layer | What it catches | When to add |
+|-------|----------------|-------------|
+| Testing Library unit tests | Rendering regressions in UI components | As part of each extraction phase |
+| Chromatic visual snapshots | Visual/style regressions across all stories | After Phase 1 (Storybook has stories) |
+| ESLint architectural rule | New violations of the two-tier rule | **After Phase 7** (migration complete — would fail CI on all existing violations if added earlier) |
+
+The ESLint rule is the most powerful long-term guard but would block every PR until migration is complete, so it is deliberately the last step.
+
+---
+
+## Why this order
+
+Each phase is independently shippable and leaves the app fully working. Later phases depend on the naming conventions and patterns established in earlier ones. Storybook is installed before domain work begins so stories can be written as part of each phase rather than retrofitted.
+
+---
+
+## Phase 1 — Foundation
+
+### 1.1 Install and configure Storybook
+
+- Add Storybook with the Vite + React + Tailwind preset
+- Point it at `src/ui/**/*.stories.tsx` and `src/domains/**/ui/**/*.stories.tsx`
+- Confirm Tailwind v4 classes render correctly inside Storybook
+- Add `npm run storybook` to CLAUDE.md Common Commands
+
+### 1.2 Write stories for existing `src/ui/` primitives
+
+For each existing primitive, write a `.stories.tsx` file next to it:
+- `PrimaryButton`, `SecondaryButton`, `TextButton`
+- `LoadingSkeleton`
+- `Dropdown`, `Popover`
+- `ConfirmDialog`
+- `ErrorComponent`
+
+This validates the Storybook setup and documents the current primitive API.
+
+### 1.3 Write Testing Library unit tests for existing `src/ui/` primitives
+
+For each primitive, write a `.spec.tsx` file next to it that:
+- Renders the component with representative props (seeded from the same mock data used in stories)
+- Asserts on visible output (text, ARIA roles, disabled state) — not on CSS classes
+- Covers any conditional rendering branches
+
+These tests run in CI from day one and establish the baseline before any refactoring.
+
+### 1.4 Set up Chromatic
+
+- Connect the repository to Chromatic
+- Add `chromatic --project-token=...` as a CI step after Storybook build
+- Accept the initial baseline snapshots from step 1.2
+- From this point on, every PR that changes a story shows a visual diff
+
+### 1.5 Create `src/domains/*/ui/` directories
+
+Create the `ui/` subdirectory inside each domain that has components:
+- `src/domains/polls/ui/`
+- `src/domains/runs/ui/`
+- `src/domains/economy/ui/`
+- `src/domains/ranking/ui/`
+
+No files yet — just the scaffolding so the pattern is visible.
+
+---
+
+## Phase 2 — Global shared components
+
+**Target:** `src/components/` (layouts, navigation, auth).
+
+These are the most reused components. Splitting them first proves the pattern at low risk.
+
+For each component in `src/components/`:
+1. Extract all HTML/CSS into a sibling `src/ui/` primitive (or a new `src/components/ui/` if it is layout-only).
+2. Reduce the original file to a pure composition component that calls hooks/context and passes props.
+3. Write a Storybook story for the extracted primitive.
+4. Write a Testing Library unit test for the extracted primitive.
+
+Key targets:
+- Navigation/header components
+- Layout wrappers
+- Auth guard wrappers (the guard logic stays in the component; only the rendered chrome moves to UI)
+
+---
+
+## Phase 3 — `src/domains/economy/`
+
+Economy is the cleanest domain. `useArchiveState` already abstracts state correctly; `BorderShop.component.tsx` is close to correct. This makes it the lowest-effort domain to demonstrate the full pattern end-to-end.
+
+### Steps
+1. Create `src/domains/economy/ui/BorderShopUI.ui.tsx` — extract all HTML/CSS from `BorderShop.component.tsx` into a pure props component.
+2. Reduce `BorderShop.component.tsx` to call `useArchiveState` and pass results to `BorderShopUI`.
+3. Write `BorderShopUI.stories.tsx` seeded with `createMockArchiveState`.
+4. Write `BorderShopUI.spec.tsx` — renders with mock props, asserts on visible output.
+5. Repeat for `ShopContainer`: extract `ShopContainerUI`, write story and unit test.
+6. Extract inline mutations from `ShopContainer` into `useInstallConfig`, `useRerollShop`, `useSkipShop` hooks (from the analysis: medium-severity violation).
+
+---
+
+## Phase 4 — `src/domains/ranking/`
+
+### Steps
+1. Move `createServerFn` out of `useCurrentSeason.hook.ts` → `src/domains/ranking/api/ranking.ts`.
+2. Register leaderboard query key in `src/domains/shared/queryKeys.ts`.
+3. Extract `useLeaderboard(categoryCode)` hook from `Leaderboard.component.tsx`.
+4. Create `src/domains/ranking/ui/LeaderboardUI.ui.tsx` — extract all HTML/CSS, add story and unit test.
+5. Reduce `Leaderboard.component.tsx` to composition only.
+
+---
+
+## Phase 5 — `src/domains/runs/`
+
+The runs domain already has good mutation hooks. The main work is visual extraction.
+
+### Steps
+1. Create `ui/` components for each existing domain component (e.g. `RunHeaderUI`, `UpgradeCardUI`, `PipelineSectionUI`).
+2. Write stories and unit tests for each, seeded from existing mock factories.
+3. Reduce each `*.component.tsx` to composition only.
+
+---
+
+## Phase 6 — `src/domains/polls/` (largest, highest-impact)
+
+This domain has the most violations. Tackle in this order to avoid cascading breakage:
+
+### 6.1 Move server functions out of component files
+- Move `getScoreBreakdown`, `getCommunityStats`, `getRandomAnswer` from `DailyPollContainer.component.tsx` → `src/domains/polls/api/polls.ts`
+- Move `getCategoryWeights` from `CategoryWeightsDisplay.component.tsx` → `src/domains/polls/api/polls.ts`
+- Update all import sites (`daily-poll/index.tsx`, etc.)
+
+### 6.2 Extract hooks
+- `useSubmitDailyPoll` — owns the primary mutation, the five post-answer state values, query invalidation, and navigation. Extracted from `DailyPollContainer`.
+- `useDeinstallConfig` — shared hook consumed by both `DailyPollContainer` and `progress.tsx` (eliminates the duplication identified in the analysis).
+- `useCategoryWeights` — wraps the query for `CategoryWeightsDisplay`.
+
+### 6.3 Extract UI components, write stories and unit tests
+- `DailyPollContainerUI` — receives score, upgrade cards, evaluation context, submission handler as props.
+- `CategoryWeightsDisplayUI` — receives `{ category: string; percentage: number }[]` as a prop.
+- `PollOptionsFormUI` — the form is already close; extract the remaining HTML.
+
+### 6.4 Reduce component files to composition only
+
+---
+
+## Phase 7 — Routes (`src/routes/`)
+
+By this phase all domain UI is in `ui/` components. Routes only need to:
+1. Read loader data.
+2. Call domain composition components or (for simple cases) domain UI components directly.
+3. Contain zero HTML/CSS themselves.
+
+Key route files to clean up (identified in analysis):
+- `src/routes/_authed/admin.tsx` — move 4 server functions + Drizzle queries to `src/domains/ranking/api/` and an admin handler; convert manual loading state to TanStack Query mutations; extract `AdminPanelUI`.
+- `src/routes/start.tsx` — extract `useStartRun` hook for the inline mutation.
+- `src/routes/_authed/progress.tsx` — use shared `useDeinstallConfig` hook (from Phase 6.2).
+- `src/routes/stats.tsx` — move `computeRunStats` to `src/domains/runs/utils/runStats.ts`.
+
+---
+
+## Phase 8 — Enforce via ESLint
+
+**Only add this after Phase 7 is complete.** At that point there are zero existing violations, so the rule becomes a pure guard against regression rather than a source of CI failures.
+
+Add an ESLint rule (or a custom script) that:
+- Flags any file in `src/routes/` or `src/domains/*/components/` that contains an HTML tag or a Tailwind class string.
+- Flags any file in `src/ui/` or `src/domains/*/ui/` that imports from `@tanstack/react-query`, `@tanstack/react-router`, or `~/domains/*/api/`.
+
+This makes the architectural constraint machine-checkable so it cannot regress silently.
+
+---
+
+## Definition of Done (per phase)
+
+- [ ] All HTML/CSS for the scope is in `src/ui/` or `src/domains/*/ui/` files
+- [ ] Every extracted UI component has a Storybook story seeded from a mock factory
+- [ ] Every extracted UI component has a Testing Library unit test asserting on visible output
+- [ ] Chromatic accepts the new/changed snapshots
+- [ ] Composition components in scope contain zero HTML tags and zero Tailwind classes
+- [ ] `npm run build` passes
+- [ ] `npm test` passes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "devvoted",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "devvoted",
-			"version": "1.0.0",
+			"version": "1.2.0",
 			"license": "ISC",
 			"dependencies": {
 				"@sentry/react": "^10.30.0",
@@ -30,7 +30,11 @@
 				"type-fest": "^5.3.1"
 			},
 			"devDependencies": {
+				"@storybook/addon-themes": "^10.4.5",
+				"@storybook/react": "^10.4.5",
+				"@storybook/react-vite": "^10.4.5",
 				"@tailwindcss/vite": "^4.1.18",
+				"@testing-library/dom": "^10.4.1",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.1",
 				"@testing-library/user-event": "^14.6.1",
@@ -50,12 +54,16 @@
 				"postcss": "^8.5.1",
 				"prettier": "^3.7.4",
 				"sonarqube-scanner": "^4.3.2",
+				"storybook": "^10.4.5",
 				"tailwindcss": "^4.1.18",
 				"tsx": "^4.20.6",
 				"typescript": "^5.9.3",
 				"vite": "^7.3.0",
 				"vite-tsconfig-paths": "^6.0.1",
 				"vitest": "^4.0.15"
+			},
+			"engines": {
+				"node": ">=24"
 			}
 		},
 		"node_modules/@acemir/cssom": {
@@ -582,20 +590,20 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@emnapi/core": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
-			"integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+			"integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.0",
+				"@emnapi/wasi-threads": "1.2.1",
 				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-			"integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+			"integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -603,9 +611,9 @@
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-			"integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -1867,6 +1875,110 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
+		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.7.0.tgz",
+			"integrity": "sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"glob": "^13.0.1",
+				"react-docgen-typescript": "^2.2.2"
+			},
+			"peerDependencies": {
+				"typescript": ">= 4.3.x",
+				"vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/lru-cache": {
+			"version": "11.5.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1924,19 +2036,21 @@
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-			"integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+			"integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/core": "^1.7.1",
-				"@emnapi/runtime": "^1.7.1",
-				"@tybys/wasm-util": "^0.10.1"
+				"@tybys/wasm-util": "^0.10.2"
 			},
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
 			}
 		},
 		"node_modules/@oozcitak/dom": {
@@ -2316,6 +2430,652 @@
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
+		},
+		"node_modules/@oxc-parser/binding-android-arm-eabi": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.127.0.tgz",
+			"integrity": "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-android-arm64": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.127.0.tgz",
+			"integrity": "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-darwin-arm64": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.127.0.tgz",
+			"integrity": "sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-darwin-x64": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.127.0.tgz",
+			"integrity": "sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-freebsd-x64": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.127.0.tgz",
+			"integrity": "sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.127.0.tgz",
+			"integrity": "sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.127.0.tgz",
+			"integrity": "sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.127.0.tgz",
+			"integrity": "sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-arm64-musl": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.127.0.tgz",
+			"integrity": "sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.127.0.tgz",
+			"integrity": "sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.127.0.tgz",
+			"integrity": "sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.127.0.tgz",
+			"integrity": "sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.127.0.tgz",
+			"integrity": "sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-x64-gnu": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.127.0.tgz",
+			"integrity": "sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-x64-musl": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.127.0.tgz",
+			"integrity": "sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-openharmony-arm64": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.127.0.tgz",
+			"integrity": "sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-wasm32-wasi": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.127.0.tgz",
+			"integrity": "sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.9.2",
+				"@emnapi/runtime": "1.9.2",
+				"@napi-rs/wasm-runtime": "^1.1.4"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.127.0.tgz",
+			"integrity": "sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.127.0.tgz",
+			"integrity": "sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-win32-x64-msvc": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.127.0.tgz",
+			"integrity": "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-project/types": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+			"integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@oxc-resolver/binding-android-arm-eabi": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.20.0.tgz",
+			"integrity": "sha512-IjfWOXRgJFNdORDl+Uf1aibNgZY2guOD3zmOhx1BGVb/MIiqlFTdmjpQNplSN58lhWehnX4UNqC3QwpUo8pjJg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-android-arm64": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.20.0.tgz",
+			"integrity": "sha512-QqslZAuFQG8Q9xm7JuIn8JUbvywhSBMVhuQHtYW+auirZJloS41oxUUaBXk7uUhZJgp44c5zQLeVvmFaDQB+2Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-darwin-arm64": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.20.0.tgz",
+			"integrity": "sha512-MUcavykj2ewlR+kc5arpg4tC2RvzJkUxWtNv74pf7lcNk00GpIpN43vXMj+j6r4eMmfZhlb8hueKoIb8e9kAGQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-darwin-x64": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.20.0.tgz",
+			"integrity": "sha512-BGB16nRUK5Etiv//ihPyzj8Lj1px0mhh4YIfe0FDf045ywknfSm0GEbiRESpr6Q4K82AvnyaRIhhluHByvS4bg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-freebsd-x64": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.20.0.tgz",
+			"integrity": "sha512-JZgtePaqj3qmD5XFHJaSLWzHRxQu0LaPkdoM1KJXYADvAaa83ijXHclV3ej3CueeW0wxfIAbGCZVP45J0CA7uQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.20.0.tgz",
+			"integrity": "sha512-hOQ/p3ry3v3SchUBXicrrnszaI/UmYzM4wtS4RGfwgVUX7a+HbyQSzJ5aOzu+o6XZkFkS3ZXN4PZAzhOb77OSg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.20.0.tgz",
+			"integrity": "sha512-2ArPksaw0AqeuGBfoS715VF+JvJQAhD2niWgjE5hVO+L+nAfikVQopvngCMX9x4BD8itWoQ3dnikrQyl5Ho5Jg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.20.0.tgz",
+			"integrity": "sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.20.0.tgz",
+			"integrity": "sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.20.0.tgz",
+			"integrity": "sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.20.0.tgz",
+			"integrity": "sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.20.0.tgz",
+			"integrity": "sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.20.0.tgz",
+			"integrity": "sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.20.0.tgz",
+			"integrity": "sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-x64-musl": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.20.0.tgz",
+			"integrity": "sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-openharmony-arm64": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.20.0.tgz",
+			"integrity": "sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-wasm32-wasi": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.20.0.tgz",
+			"integrity": "sha512-Tn0y1XOFYHNfK1wp1Z5QK8Rcld/bsOwRISQXfqAZ5IBpv8Gz1IvV39fUWNprqNdRizgcvFhOzWwFun2zkJsyBg==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.10.0",
+				"@emnapi/runtime": "1.10.0",
+				"@napi-rs/wasm-runtime": "^1.1.4"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.20.0.tgz",
+			"integrity": "sha512-qPi25YNPe4YenS8MgsQU2+bIFHxxpLx1LVna2444cEHqNPhNjvWf9zqj4aWE43H9LpAsTmkkAlA3eL5ElBU3mA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.20.0.tgz",
+			"integrity": "sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
 		},
 		"node_modules/@oxc-transform/binding-android-arm-eabi": {
 			"version": "0.110.0",
@@ -3050,6 +3810,36 @@
 			"integrity": "sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w==",
 			"license": "MIT"
 		},
+		"node_modules/@rollup/pluginutils": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+			"integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"estree-walker": "^2.0.2",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
@@ -3472,6 +4262,185 @@
 			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@storybook/addon-themes": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-10.4.5.tgz",
+			"integrity": "sha512-UrGgxrgNLLutOOtkBiXOHhF2uJCqN8VG7qtQhhCPNkoSy7ylaIJmvIYoEhjopIeweaFzAzrVjO4jzMYOKKTRvA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ts-dedent": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			},
+			"peerDependencies": {
+				"storybook": "^10.4.5"
+			}
+		},
+		"node_modules/@storybook/builder-vite": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.4.5.tgz",
+			"integrity": "sha512-UFtMIojDT61OWhc2ti0wf6pUNlBRLYixyygXXTolaCxdACum6SOgJim+mEZE4S3VuTaZgjTRNyoc0WSJPqjQ2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@storybook/csf-plugin": "10.4.5",
+				"ts-dedent": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			},
+			"peerDependencies": {
+				"storybook": "^10.4.5",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@storybook/csf-plugin": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.4.5.tgz",
+			"integrity": "sha512-OsSsSLulBmdKTz7MIKLgoWADZB8bjYaAjZZy/THdI50G/TTd6FVSXQMCM7GO7xQZ/EguRY1PmjOVCLbgcnXsDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"unplugin": "^2.3.5"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			},
+			"peerDependencies": {
+				"esbuild": "*",
+				"rollup": "*",
+				"storybook": "^10.4.5",
+				"vite": "*",
+				"webpack": "*"
+			},
+			"peerDependenciesMeta": {
+				"esbuild": {
+					"optional": true
+				},
+				"rollup": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				},
+				"webpack": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@storybook/global": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@storybook/global/-/global-5.0.0.tgz",
+			"integrity": "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@storybook/icons": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-2.0.2.tgz",
+			"integrity": "sha512-KZBCpXsshAIjczYNXR/rlxEtCUX/eAbpFNwKi8bcOomrLA4t/SyPz5RF+lVPO2oZBUE4sAkt43mfJUevQDSEEw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@storybook/react": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.4.5.tgz",
+			"integrity": "sha512-VMEqdjplKJTf8KA5ER9kJp51dOJKlgvb9H0F45RL1pX42+briPmTe8VL0yJR3GyMBpicFbFpjZ7AC22DgZ6vNg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@storybook/global": "^5.0.0",
+				"@storybook/react-dom-shim": "10.4.5",
+				"react-docgen": "^8.0.2",
+				"react-docgen-typescript": "^2.2.2"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"storybook": "^10.4.5",
+				"typescript": ">= 4.9.x"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				},
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@storybook/react-dom-shim": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.4.5.tgz",
+			"integrity": "sha512-fKdikHC7cDgSuaBirPwvgFBmfO//3cln0y3GmDEQchUV2VFDrZ7ZL1/iH7dA21XuiFFhQcDRRkArJmvMAGG5Cg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"storybook": "^10.4.5"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@storybook/react-vite": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.4.5.tgz",
+			"integrity": "sha512-hppQmaI7UK+bd0VHP4rtPSwQptL+F0DkGy3ZwH89z2+KqNp8vmX2BFTKKaGRDc+wie8f/0fxWNLwSP2ZYUhG/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
+				"@rollup/pluginutils": "^5.0.2",
+				"@storybook/builder-vite": "10.4.5",
+				"@storybook/react": "10.4.5",
+				"empathic": "^2.0.0",
+				"magic-string": "^0.30.0",
+				"react-docgen": "^8.0.0",
+				"resolve": "^1.22.8",
+				"tsconfig-paths": "^4.2.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"storybook": "^10.4.5",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
 		},
 		"node_modules/@supabase/auth-js": {
 			"version": "2.99.1",
@@ -4390,7 +5359,6 @@
 			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.10.4",
 				"@babel/runtime": "^7.12.5",
@@ -4485,9 +5453,9 @@
 			}
 		},
 		"node_modules/@tybys/wasm-util": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+			"integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -4499,8 +5467,7 @@
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
@@ -4578,6 +5545,13 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
 			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/doctrine": {
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
+			"integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4683,6 +5657,13 @@
 				"@types/tough-cookie": "*",
 				"form-data": "^2.5.5"
 			}
+		},
+		"node_modules/@types/resolve": {
+			"version": "1.20.6",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
+			"integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/tough-cookie": {
 			"version": "4.0.5",
@@ -4884,6 +5865,13 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/@webcontainer/env": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@webcontainer/env/-/env-1.1.1.tgz",
+			"integrity": "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/abort-controller": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -4959,7 +5947,6 @@
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -5423,6 +6410,22 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/bundle-name": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"run-applescript": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/call-bind-apply-helpers": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -5515,6 +6518,16 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/check-error": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+			"integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
 			}
 		},
 		"node_modules/cheerio": {
@@ -6027,6 +7040,16 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/deep-eql": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/deepmerge": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -6034,6 +7057,49 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/default-browser": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+			"integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bundle-name": "^4.1.0",
+				"default-browser-id": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser-id": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+			"integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/define-lazy-prop": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/delayed-stream": {
@@ -6087,13 +7153,25 @@
 				"node": ">=0.3.1"
 			}
 		},
+		"node_modules/doctrine": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/dom-accessibility-api": {
 			"version": "0.5.16",
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/dom-serializer": {
 			"version": "2.0.0",
@@ -6360,6 +7438,16 @@
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"license": "MIT"
 		},
+		"node_modules/empathic": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+			"integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/encoding-sniffer": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
@@ -6573,6 +7661,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/event-target-shim": {
@@ -7356,9 +8454,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7663,6 +8761,22 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/is-core-module": {
+			"version": "2.16.2",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+			"integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hasown": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-decimal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
@@ -7671,6 +8785,22 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/is-docker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-extglob": {
@@ -7720,6 +8850,25 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^3.0.0"
+			},
+			"bin": {
+				"is-inside-container": "cli.js"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -7756,6 +8905,22 @@
 			"optional": true,
 			"engines": {
 				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-wsl": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+			"integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-inside-container": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -8468,6 +9633,13 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/loupe": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+			"integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/lowlight": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
@@ -8526,7 +9698,6 @@
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -9295,6 +10466,16 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/minipass": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -9700,6 +10881,25 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/open": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+			"integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"default-browser": "^5.2.1",
+				"define-lazy-prop": "^3.0.0",
+				"is-inside-container": "^1.0.0",
+				"wsl-utils": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/oxc-minify": {
 			"version": "0.110.0",
 			"resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.110.0.tgz",
@@ -9732,6 +10932,75 @@
 				"@oxc-minify/binding-win32-arm64-msvc": "0.110.0",
 				"@oxc-minify/binding-win32-ia32-msvc": "0.110.0",
 				"@oxc-minify/binding-win32-x64-msvc": "0.110.0"
+			}
+		},
+		"node_modules/oxc-parser": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.127.0.tgz",
+			"integrity": "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "^0.127.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			},
+			"optionalDependencies": {
+				"@oxc-parser/binding-android-arm-eabi": "0.127.0",
+				"@oxc-parser/binding-android-arm64": "0.127.0",
+				"@oxc-parser/binding-darwin-arm64": "0.127.0",
+				"@oxc-parser/binding-darwin-x64": "0.127.0",
+				"@oxc-parser/binding-freebsd-x64": "0.127.0",
+				"@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0",
+				"@oxc-parser/binding-linux-arm-musleabihf": "0.127.0",
+				"@oxc-parser/binding-linux-arm64-gnu": "0.127.0",
+				"@oxc-parser/binding-linux-arm64-musl": "0.127.0",
+				"@oxc-parser/binding-linux-ppc64-gnu": "0.127.0",
+				"@oxc-parser/binding-linux-riscv64-gnu": "0.127.0",
+				"@oxc-parser/binding-linux-riscv64-musl": "0.127.0",
+				"@oxc-parser/binding-linux-s390x-gnu": "0.127.0",
+				"@oxc-parser/binding-linux-x64-gnu": "0.127.0",
+				"@oxc-parser/binding-linux-x64-musl": "0.127.0",
+				"@oxc-parser/binding-openharmony-arm64": "0.127.0",
+				"@oxc-parser/binding-wasm32-wasi": "0.127.0",
+				"@oxc-parser/binding-win32-arm64-msvc": "0.127.0",
+				"@oxc-parser/binding-win32-ia32-msvc": "0.127.0",
+				"@oxc-parser/binding-win32-x64-msvc": "0.127.0"
+			}
+		},
+		"node_modules/oxc-resolver": {
+			"version": "11.20.0",
+			"resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.20.0.tgz",
+			"integrity": "sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			},
+			"optionalDependencies": {
+				"@oxc-resolver/binding-android-arm-eabi": "11.20.0",
+				"@oxc-resolver/binding-android-arm64": "11.20.0",
+				"@oxc-resolver/binding-darwin-arm64": "11.20.0",
+				"@oxc-resolver/binding-darwin-x64": "11.20.0",
+				"@oxc-resolver/binding-freebsd-x64": "11.20.0",
+				"@oxc-resolver/binding-linux-arm-gnueabihf": "11.20.0",
+				"@oxc-resolver/binding-linux-arm-musleabihf": "11.20.0",
+				"@oxc-resolver/binding-linux-arm64-gnu": "11.20.0",
+				"@oxc-resolver/binding-linux-arm64-musl": "11.20.0",
+				"@oxc-resolver/binding-linux-ppc64-gnu": "11.20.0",
+				"@oxc-resolver/binding-linux-riscv64-gnu": "11.20.0",
+				"@oxc-resolver/binding-linux-riscv64-musl": "11.20.0",
+				"@oxc-resolver/binding-linux-s390x-gnu": "11.20.0",
+				"@oxc-resolver/binding-linux-x64-gnu": "11.20.0",
+				"@oxc-resolver/binding-linux-x64-musl": "11.20.0",
+				"@oxc-resolver/binding-openharmony-arm64": "11.20.0",
+				"@oxc-resolver/binding-wasm32-wasi": "11.20.0",
+				"@oxc-resolver/binding-win32-arm64-msvc": "11.20.0",
+				"@oxc-resolver/binding-win32-x64-msvc": "11.20.0"
 			}
 		},
 		"node_modules/oxc-transform": {
@@ -9934,6 +11203,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/path-scurry": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -9961,6 +11237,16 @@
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
 			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
 			"license": "MIT"
+		},
+		"node_modules/pathval": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+			"integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.16"
+			}
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
@@ -10049,7 +11335,6 @@
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -10143,6 +11428,51 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/react-docgen": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-8.0.3.tgz",
+			"integrity": "sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.28.0",
+				"@babel/traverse": "^7.28.0",
+				"@babel/types": "^7.28.2",
+				"@types/babel__core": "^7.20.5",
+				"@types/babel__traverse": "^7.20.7",
+				"@types/doctrine": "^0.0.9",
+				"@types/resolve": "^1.20.2",
+				"doctrine": "^3.0.0",
+				"resolve": "^1.22.1",
+				"strip-indent": "^4.0.0"
+			},
+			"engines": {
+				"node": "^20.9.0 || >=22"
+			}
+		},
+		"node_modules/react-docgen-typescript": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.4.0.tgz",
+			"integrity": "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"typescript": ">= 4.3.x"
+			}
+		},
+		"node_modules/react-docgen/node_modules/strip-indent": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+			"integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/react-dom": {
 			"version": "19.2.4",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
@@ -10160,8 +11490,7 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/react-markdown": {
 			"version": "10.1.0",
@@ -10348,6 +11677,28 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/resolve": {
+			"version": "1.22.12",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+			"integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"is-core-module": "^2.16.1",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/resolve-pkg-maps": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -10470,6 +11821,19 @@
 			"resolved": "https://registry.npmjs.org/rou3/-/rou3-0.8.1.tgz",
 			"integrity": "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==",
 			"license": "MIT"
+		},
+		"node_modules/run-applescript": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+			"integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
@@ -10750,6 +12114,151 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/storybook": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/storybook/-/storybook-10.4.5.tgz",
+			"integrity": "sha512-QZuv1gS9Tf9RMCjDw5JOfv1XSB5IhU0uhSKQNS7l/N9zDpmSydirCspkCNT9e0zkFfPkZ9vmQUTzHY/BA07saA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@storybook/global": "^5.0.0",
+				"@storybook/icons": "^2.0.2",
+				"@testing-library/jest-dom": "^6.9.1",
+				"@testing-library/user-event": "^14.6.1",
+				"@vitest/expect": "3.2.4",
+				"@vitest/spy": "3.2.4",
+				"@webcontainer/env": "^1.1.1",
+				"esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0",
+				"open": "^10.2.0",
+				"oxc-parser": "^0.127.0",
+				"oxc-resolver": "^11.19.1",
+				"recast": "^0.23.5",
+				"semver": "^7.7.3",
+				"use-sync-external-store": "^1.5.0",
+				"ws": "^8.18.0"
+			},
+			"bin": {
+				"storybook": "dist/bin/dispatcher.js"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"prettier": "^2 || ^3",
+				"vite-plus": "^0.1.15"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"prettier": {
+					"optional": true
+				},
+				"vite-plus": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/storybook/node_modules/@vitest/expect": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+			"integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "3.2.4",
+				"@vitest/utils": "3.2.4",
+				"chai": "^5.2.0",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/storybook/node_modules/@vitest/pretty-format": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+			"integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/storybook/node_modules/@vitest/spy": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+			"integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyspy": "^4.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/storybook/node_modules/@vitest/utils": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+			"integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.4",
+				"loupe": "^3.1.4",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/storybook/node_modules/chai": {
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+			"integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"assertion-error": "^2.0.1",
+				"check-error": "^2.1.1",
+				"deep-eql": "^5.0.1",
+				"loupe": "^3.1.0",
+				"pathval": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/storybook/node_modules/semver": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/storybook/node_modules/tinyrainbow": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+			"integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/stream-events": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
@@ -10906,6 +12415,16 @@
 				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
 			}
 		},
+		"node_modules/strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/strip-indent": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -10968,6 +12487,19 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/symbol-tree": {
@@ -11171,6 +12703,16 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/tinyspy": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+			"integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/tldts": {
 			"version": "7.0.25",
 			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.25.tgz",
@@ -11249,6 +12791,16 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/ts-dedent": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+			"integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.10"
+			}
+		},
 		"node_modules/tsconfck": {
 			"version": "3.1.6",
 			"resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
@@ -11268,6 +12820,21 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/tsconfig-paths": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+			"integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json5": "^2.2.2",
+				"minimist": "^1.2.6",
+				"strip-bom": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/tslib": {
@@ -12940,6 +14507,22 @@
 				"utf-8-validate": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/wsl-utils": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+			"integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-wsl": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/xml": {

--- a/package.json
+++ b/package.json
@@ -110,6 +110,5 @@
 		"*.{json,md}": [
 			"prettier --write"
 		]
-	},
-	"packageManager": "yarn@4.14.1+sha512.64df448055b2d37ba269d7db535a469b8da93f8ef1140c25fd7a83c00a8fbaacb214ca0e02553b92a2c54cef78bb67d0b4817fab02001df0e24fac0faccc3b42"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
 		"db:refresh": "npm run db:reset && npm run db:generate && npm run db:push && npm run db:seed",
 		"export:firebase": "node scripts/export-polls.js",
 		"prepare": "husky",
-		"test-category-weights": "tsx scripts/test-weights.ts"
+		"test-category-weights": "tsx scripts/test-weights.ts",
+		"storybook": "storybook dev -p 6006",
+		"build-storybook": "storybook build"
 	},
 	"author": "marciano_schildmeijer@live.nl",
 	"license": "ISC",
@@ -68,7 +70,11 @@
 		"type-fest": "^5.3.1"
 	},
 	"devDependencies": {
+		"@storybook/addon-themes": "^10.4.5",
+		"@storybook/react": "^10.4.5",
+		"@storybook/react-vite": "^10.4.5",
 		"@tailwindcss/vite": "^4.1.18",
+		"@testing-library/dom": "^10.4.1",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.1",
 		"@testing-library/user-event": "^14.6.1",
@@ -88,6 +94,7 @@
 		"postcss": "^8.5.1",
 		"prettier": "^3.7.4",
 		"sonarqube-scanner": "^4.3.2",
+		"storybook": "^10.4.5",
 		"tailwindcss": "^4.1.18",
 		"tsx": "^4.20.6",
 		"typescript": "^5.9.3",

--- a/src/components/Content.component.tsx
+++ b/src/components/Content.component.tsx
@@ -1,19 +1,13 @@
 import { Poll } from "~/domains/polls/models/poll.model";
+import { ContentSection } from "~/ui/ContentSection.component";
 
 type ContentProps = {
 	poll?: Poll;
 	children: React.ReactNode;
 };
 
-const Content = ({ poll, children }: ContentProps) => {
-	return (
-		<section
-			data-category-theme={poll?.categoryCode}
-			className="w-full sm:max-w-5xl mx-auto p-4"
-		>
-			{children}
-		</section>
-	);
-};
+const Content = ({ poll, children }: ContentProps) => (
+	<ContentSection categoryCode={poll?.categoryCode}>{children}</ContentSection>
+);
 
 export default Content;

--- a/src/components/DefaultCatchBoundary.component.tsx
+++ b/src/components/DefaultCatchBoundary.component.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-router";
 
 import type { ErrorComponentProps } from "@tanstack/react-router";
+import { CatchBoundaryUI } from "~/ui/CatchBoundaryUI.component";
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
 	const router = useRouter();
@@ -17,38 +18,31 @@ export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
 
 	console.error(error);
 
+	const navigationLink = isRoot ? (
+		<Link
+			to="/"
+			className="px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded text-white uppercase font-extrabold"
+		>
+			Home
+		</Link>
+	) : (
+		<Link
+			to="/"
+			className="px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded text-white uppercase font-extrabold"
+			onClick={(e) => {
+				e.preventDefault();
+				window.history.back();
+			}}
+		>
+			Go Back
+		</Link>
+	);
+
 	return (
-		<div className="min-w-0 flex-1 p-4 flex flex-col items-center justify-center gap-6">
-			<ErrorComponent error={error} />
-			<div className="flex gap-2 items-center flex-wrap">
-				<button
-					onClick={() => {
-						router.invalidate();
-					}}
-					className={`px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded text-white uppercase font-extrabold`}
-				>
-					Try Again
-				</button>
-				{isRoot ? (
-					<Link
-						to="/"
-						className={`px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded text-white uppercase font-extrabold`}
-					>
-						Home
-					</Link>
-				) : (
-					<Link
-						to="/"
-						className={`px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded text-white uppercase font-extrabold`}
-						onClick={(e) => {
-							e.preventDefault();
-							window.history.back();
-						}}
-					>
-						Go Back
-					</Link>
-				)}
-			</div>
-		</div>
+		<CatchBoundaryUI
+			errorDisplay={<ErrorComponent error={error} />}
+			onRetry={() => router.invalidate()}
+			navigationLink={navigationLink}
+		/>
 	);
 }

--- a/src/components/DevPollNavigator.component.tsx
+++ b/src/components/DevPollNavigator.component.tsx
@@ -1,6 +1,8 @@
 import { useNavigate } from "@tanstack/react-router";
 import { addDays, format } from "date-fns";
 
+import { DevPollNavigatorUI } from "~/ui/DevPollNavigatorUI.component";
+
 type DevPollNavigatorProps = {
 	currentDate: string;
 	hasCustomDate: boolean;
@@ -36,24 +38,11 @@ export const DevPollNavigator = ({
 	};
 
 	return (
-		<div className="max-w-5xl mx-auto mb-4 flex gap-2 items-center">
-			<button
-				type="button"
-				onClick={handleRandomPoll}
-				className="px-3 py-1 text-xs bg-yellow-600 hover:bg-yellow-500 text-black rounded"
-			>
-				Random Poll
-			</button>
-			{hasCustomDate && (
-				<button
-					type="button"
-					onClick={handleResetToToday}
-					className="px-3 py-1 text-xs bg-gray-600 hover:bg-gray-500 text-white rounded"
-				>
-					Today
-				</button>
-			)}
-			<span className="text-xs text-gray-500">Viewing: {currentDate}</span>
-		</div>
+		<DevPollNavigatorUI
+			currentDate={currentDate}
+			hasCustomDate={hasCustomDate}
+			onRandomPoll={handleRandomPoll}
+			onResetToToday={handleResetToToday}
+		/>
 	);
 };

--- a/src/components/Footer.component.tsx
+++ b/src/components/Footer.component.tsx
@@ -5,52 +5,33 @@ import { format } from "date-fns";
 import { configs } from "~/domains/economy/data/configs";
 import { getAllPolls } from "~/domains/polls/api/polls";
 import { getCategories } from "~/domains/shared/categories";
+import { FooterUI } from "~/ui/FooterUI.component";
 
 declare const __LAST_COMMIT_DATE__: string;
 
 const Footer = () => {
-	const { data, error, isLoading } = useQuery({
+	const { data, isLoading } = useQuery({
 		queryKey: ["all-polls"],
 		queryFn: () => getAllPolls(),
-		staleTime: 1000 * 60 * 30, // Cache for 30 min
+		staleTime: 1000 * 60 * 30,
 	});
 
+	const pollCount = !isLoading && data?.success ? data.data.length : null;
+
 	return (
-		<footer className="p-4 mt-auto bg-zinc-900 text-white flex flex-col items-center">
-			<section className="flex gap-2 items-center">
-				{!isLoading && !error && data?.success && (
-					<div>{data.data.length} polls</div>
-				)}
-				<span>·</span>
-				<div>{getCategories().length} categories</div>
-				<span>·</span>
-				<div>{configs.length} configs</div>
-				<span>·</span>
+		<FooterUI
+			pollCount={pollCount}
+			isLoading={isLoading}
+			categoryCount={getCategories().length}
+			configCount={configs.length}
+			lastCommitDate={format(new Date(__LAST_COMMIT_DATE__), "d MMM yyyy")}
+			statsLink={
 				<Link to="/stats" className="underline">
 					See all game info stats
 				</Link>
-			</section>
-
-			<hr className="border-theme my-4" />
-			<section className="">
-				<p>
-					A crazy roguelike obsession build with craftsmanship, passion, ❤️ &
-					Tanstack Start by Marciano Schildmeijer | EST may 2022 | Last updated:{" "}
-					{format(new Date(__LAST_COMMIT_DATE__), "d MMM yyyy")}
-				</p>
-				<p className="mt-2 text-zinc-400">
-					Found a bug?{" "}
-					<a
-						href="https://github.com/marcianosr/DevVoted/issues"
-						target="_blank"
-						rel="noopener noreferrer"
-						className="text-blue-400 hover:text-blue-300 underline"
-					>
-						Report it on GitHub
-					</a>
-				</p>
-			</section>
-		</footer>
+			}
+		/>
 	);
 };
+
 export default Footer;

--- a/src/components/NotFound.component.tsx
+++ b/src/components/NotFound.component.tsx
@@ -1,25 +1,21 @@
 import { Link } from "@tanstack/react-router";
 
-export function NotFound({ children }: { children?: any }) {
+import { NotFoundUI } from "~/ui/NotFoundUI.component";
+
+export function NotFound({ children }: { children?: React.ReactNode }) {
 	return (
-		<div className="space-y-2 p-2">
-			<div className="text-gray-600 dark:text-gray-400">
-				{children || <p>The page you are looking for does not exist.</p>}
-			</div>
-			<p className="flex items-center gap-2 flex-wrap">
-				<button
-					onClick={() => window.history.back()}
-					className="bg-emerald-500 text-white px-2 py-1 rounded uppercase font-black text-sm"
-				>
-					Go back
-				</button>
+		<NotFoundUI
+			onGoBack={() => window.history.back()}
+			homeLink={
 				<Link
 					to="/"
 					className="bg-cyan-600 text-white px-2 py-1 rounded uppercase font-black text-sm"
 				>
 					Start Over
 				</Link>
-			</p>
-		</div>
+			}
+		>
+			{children}
+		</NotFoundUI>
 	);
 }

--- a/src/components/PageLayout.component.tsx
+++ b/src/components/PageLayout.component.tsx
@@ -1,12 +1,8 @@
 import Footer from "~/components/Footer.component";
+import { PageLayoutUI } from "~/ui/PageLayoutUI.component";
 
-const PageLayout = ({ children }: { children: React.ReactNode }) => {
-	return (
-		<main className="flex flex-col min-h-screen pb-24">
-			{children}
-			<Footer />
-		</main>
-	);
-};
+const PageLayout = ({ children }: { children: React.ReactNode }) => (
+	<PageLayoutUI footer={<Footer />}>{children}</PageLayoutUI>
+);
 
 export default PageLayout;

--- a/src/database/seed.ts
+++ b/src/database/seed.ts
@@ -25,6 +25,34 @@ import { getCategories, CATEGORY_CODES } from "~/domains/shared/categories";
 const DEV_UID = "f40d940b-9d3b-47f3-a73a-4dfba18b20c2";
 const ADMIN_UID = "65ad226e-e3c1-4e7f-a96d-a84156589733";
 
+const LOCAL_SUPABASE_URL = process.env.SUPABASE_URL ?? "http://localhost:54321";
+const LOCAL_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+
+const createLocalAuthUser = async (
+	id: string,
+	email: string,
+	password: string
+): Promise<void> => {
+	const res = await fetch(`${LOCAL_SUPABASE_URL}/auth/v1/admin/users`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			apikey: LOCAL_SERVICE_ROLE_KEY,
+			Authorization: `Bearer ${LOCAL_SERVICE_ROLE_KEY}`,
+		},
+		body: JSON.stringify({ id, email, password, email_confirm: true }),
+	});
+
+	if (!res.ok) {
+		const body = (await res.json()) as { error_code?: string; msg?: string };
+		const alreadyExists =
+			body.error_code === "user_already_exists" ||
+			body.msg?.toLowerCase().includes("already");
+		if (alreadyExists) return;
+		console.warn(`⚠️  Could not create auth user ${email}: ${body.msg}`);
+	}
+};
+
 // ─── FFI World Cup roster (English dub) ───────────────────────────────────────
 // Players drawn from the five FFI teams the user nominated: Inazuma Japan,
 // Unicorn (USA), Orpheus (Italy), Little Gigant (Cotarl), and Mac Roniejo.
@@ -200,14 +228,19 @@ async function seedDatabase() {
 		console.log(`ℹ️ Admin user already exists: ${adminUser.display_name}`);
 	}
 
-	// Create test user
-	console.log("\n👤 Creating test user if needed...");
+	// Create local dev auth + profile user
+	console.log("\n👤 Creating local dev user...");
+
+	const devEmail = "dev@devvoted.local";
+	const devPassword = "devvoted123";
+
+	await createLocalAuthUser(DEV_UID, devEmail, devPassword);
 
 	const testUser = {
 		id: DEV_UID,
-		display_name: "Test User",
-		email: "test@example.com",
-		role: "user" as const,
+		display_name: "Dev User",
+		email: devEmail,
+		roles: "user" as const,
 	};
 
 	const existingUser = await db
@@ -217,9 +250,9 @@ async function seedDatabase() {
 
 	if (existingUser.length === 0) {
 		await db.insert(usersTable).values(testUser);
-		console.log(`✅ Created test user: ${testUser.display_name}`);
+		console.log(`✅ Created dev user: ${testUser.email} / ${devPassword}`);
 	} else {
-		console.log(`ℹ️ Test user already exists: ${testUser.display_name}`);
+		console.log(`ℹ️ Dev user already exists: ${testUser.email}`);
 	}
 
 	// Next, ensure we have the necessary categories

--- a/src/ui/CatchBoundaryUI.component.tsx
+++ b/src/ui/CatchBoundaryUI.component.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from "react";
+
+type CatchBoundaryUIProps = {
+	errorDisplay: ReactNode;
+	onRetry: () => void;
+	navigationLink: ReactNode;
+};
+
+export const CatchBoundaryUI = ({
+	errorDisplay,
+	onRetry,
+	navigationLink,
+}: CatchBoundaryUIProps) => (
+	<div className="min-w-0 flex-1 p-4 flex flex-col items-center justify-center gap-6">
+		{errorDisplay}
+		<div className="flex gap-2 items-center flex-wrap">
+			<button
+				onClick={onRetry}
+				className="px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded text-white uppercase font-extrabold"
+			>
+				Try Again
+			</button>
+			{navigationLink}
+		</div>
+	</div>
+);

--- a/src/ui/CatchBoundaryUI.spec.tsx
+++ b/src/ui/CatchBoundaryUI.spec.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CatchBoundaryUI } from "./CatchBoundaryUI.component";
+
+describe("CatchBoundaryUI", () => {
+	it("renders the error display slot", () => {
+		render(
+			<CatchBoundaryUI
+				errorDisplay={<p>Banjo broke something.</p>}
+				onRetry={() => {}}
+				navigationLink={<a href="/">Home</a>}
+			/>
+		);
+		expect(screen.getByText("Banjo broke something.")).toBeInTheDocument();
+	});
+
+	it("calls onRetry when Try Again is clicked", async () => {
+		const onRetry = vi.fn();
+		render(
+			<CatchBoundaryUI
+				errorDisplay={<p>Error</p>}
+				onRetry={onRetry}
+				navigationLink={<a href="/">Home</a>}
+			/>
+		);
+		await userEvent.click(screen.getByRole("button", { name: "Try Again" }));
+		expect(onRetry).toHaveBeenCalledOnce();
+	});
+
+	it("renders the navigation link slot", () => {
+		render(
+			<CatchBoundaryUI
+				errorDisplay={<p>Error</p>}
+				onRetry={() => {}}
+				navigationLink={<a href="/">Go Back</a>}
+			/>
+		);
+		expect(screen.getByRole("link", { name: "Go Back" })).toBeInTheDocument();
+	});
+});

--- a/src/ui/CatchBoundaryUI.stories.tsx
+++ b/src/ui/CatchBoundaryUI.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CatchBoundaryUI } from "./CatchBoundaryUI.component";
+
+const meta: Meta<typeof CatchBoundaryUI> = {
+	component: CatchBoundaryUI,
+	title: "UI/CatchBoundaryUI",
+};
+export default meta;
+
+type Story = StoryObj<typeof CatchBoundaryUI>;
+
+export const Default: Story = {
+	args: {
+		errorDisplay: (
+			<p className="text-red-400">Something went wrong loading this page.</p>
+		),
+		onRetry: () => {},
+		navigationLink: (
+			<a
+				href="/"
+				className="px-2 py-1 bg-gray-700 rounded text-white uppercase font-extrabold text-sm"
+			>
+				Go Back
+			</a>
+		),
+	},
+};

--- a/src/ui/ConfirmDialog.spec.tsx
+++ b/src/ui/ConfirmDialog.spec.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ConfirmDialog } from "./ConfirmDialog.component";
+
+// jsdom does not implement HTMLDialogElement.showModal / close.
+// We mock them and set the `open` attribute so dialog contents become accessible.
+beforeAll(() => {
+	HTMLDialogElement.prototype.showModal = vi.fn(function (
+		this: HTMLDialogElement
+	) {
+		this.setAttribute("open", "");
+	});
+	HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+		this.removeAttribute("open");
+	});
+});
+
+const defaultProps = {
+	isOpen: true,
+	title: "Uninstall config?",
+	message: "This will remove the config and free up storage.",
+	onConfirm: vi.fn(),
+	onCancel: vi.fn(),
+};
+
+describe("ConfirmDialog", () => {
+	it("renders title and message", () => {
+		render(<ConfirmDialog {...defaultProps} />);
+		expect(screen.getByText("Uninstall config?")).toBeInTheDocument();
+		expect(
+			screen.getByText("This will remove the config and free up storage.")
+		).toBeInTheDocument();
+	});
+
+	it("renders confirm and cancel buttons", () => {
+		render(<ConfirmDialog {...defaultProps} />);
+		expect(screen.getByRole("button", { name: "Yes" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "No" })).toBeInTheDocument();
+	});
+
+	it("uses custom button labels", () => {
+		render(
+			<ConfirmDialog
+				{...defaultProps}
+				confirmText="Uninstall"
+				cancelText="Keep it"
+			/>
+		);
+		expect(
+			screen.getByRole("button", { name: "Uninstall" })
+		).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Keep it" })).toBeInTheDocument();
+	});
+
+	it("calls onConfirm when confirm button is clicked", async () => {
+		const onConfirm = vi.fn();
+		render(<ConfirmDialog {...defaultProps} onConfirm={onConfirm} />);
+		await userEvent.click(screen.getByRole("button", { name: "Yes" }));
+		expect(onConfirm).toHaveBeenCalledOnce();
+	});
+
+	it("calls onCancel when cancel button is clicked", async () => {
+		const onCancel = vi.fn();
+		render(<ConfirmDialog {...defaultProps} onCancel={onCancel} />);
+		await userEvent.click(screen.getByRole("button", { name: "No" }));
+		expect(onCancel).toHaveBeenCalledOnce();
+	});
+
+	it("disables both buttons when isConfirming", () => {
+		render(<ConfirmDialog {...defaultProps} isConfirming />);
+		screen.getAllByRole("button").forEach((btn) => {
+			expect(btn).toBeDisabled();
+		});
+	});
+
+	it("shows error message when provided", () => {
+		render(
+			<ConfirmDialog {...defaultProps} errorMessage="Something went wrong." />
+		);
+		expect(screen.getByRole("alert")).toHaveTextContent(
+			"Something went wrong."
+		);
+	});
+});

--- a/src/ui/ConfirmDialog.stories.tsx
+++ b/src/ui/ConfirmDialog.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ConfirmDialog } from "./ConfirmDialog.component";
+
+const meta: Meta<typeof ConfirmDialog> = {
+	component: ConfirmDialog,
+	title: "UI/ConfirmDialog",
+};
+export default meta;
+
+type Story = StoryObj<typeof ConfirmDialog>;
+
+export const Default: Story = {
+	args: {
+		isOpen: true,
+		title: "Uninstall config?",
+		message: "This will remove the config and free up storage.",
+		confirmText: "Uninstall",
+		cancelText: "Keep it",
+		onConfirm: () => {},
+		onCancel: () => {},
+	},
+};
+
+export const WithError: Story = {
+	args: {
+		isOpen: true,
+		title: "Delete run?",
+		message: "This action cannot be undone.",
+		errorMessage: "Failed to delete. Please try again.",
+		onConfirm: () => {},
+		onCancel: () => {},
+	},
+};
+
+export const Confirming: Story = {
+	args: {
+		isOpen: true,
+		title: "Start new run?",
+		message: "Your current run will end.",
+		isConfirming: true,
+		onConfirm: () => {},
+		onCancel: () => {},
+	},
+};

--- a/src/ui/ContentSection.component.tsx
+++ b/src/ui/ContentSection.component.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from "react";
+
+type ContentSectionProps = {
+	categoryCode?: string;
+	children: ReactNode;
+};
+
+export const ContentSection = ({
+	categoryCode,
+	children,
+}: ContentSectionProps) => (
+	<section
+		data-category-theme={categoryCode}
+		className="w-full sm:max-w-5xl mx-auto p-4"
+	>
+		{children}
+	</section>
+);

--- a/src/ui/ContentSection.spec.tsx
+++ b/src/ui/ContentSection.spec.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ContentSection } from "./ContentSection.component";
+
+describe("ContentSection", () => {
+	it("renders children", () => {
+		render(<ContentSection>Banjo-Kazooie quiz</ContentSection>);
+		expect(screen.getByText("Banjo-Kazooie quiz")).toBeInTheDocument();
+	});
+
+	it("sets data-category-theme when categoryCode is provided", () => {
+		const { container } = render(
+			<ContentSection categoryCode="react">Content</ContentSection>
+		);
+		expect(
+			container.querySelector("[data-category-theme='react']")
+		).toBeInTheDocument();
+	});
+
+	it("omits data-category-theme when categoryCode is undefined", () => {
+		const { container } = render(<ContentSection>Content</ContentSection>);
+		const section = container.querySelector("section");
+		expect(section?.getAttribute("data-category-theme")).toBeNull();
+	});
+});

--- a/src/ui/ContentSection.stories.tsx
+++ b/src/ui/ContentSection.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ContentSection } from "./ContentSection.component";
+
+const meta: Meta<typeof ContentSection> = {
+	component: ContentSection,
+	title: "UI/ContentSection",
+};
+export default meta;
+
+type Story = StoryObj<typeof ContentSection>;
+
+export const Default: Story = {
+	args: {
+		children: <p>Poll content goes here.</p>,
+	},
+};
+
+export const WithCategoryTheme: Story = {
+	args: {
+		categoryCode: "react",
+		children: <p>React category content.</p>,
+	},
+};

--- a/src/ui/DevPollNavigatorUI.component.tsx
+++ b/src/ui/DevPollNavigatorUI.component.tsx
@@ -1,0 +1,33 @@
+type DevPollNavigatorUIProps = {
+	currentDate: string;
+	hasCustomDate: boolean;
+	onRandomPoll: () => void;
+	onResetToToday: () => void;
+};
+
+export const DevPollNavigatorUI = ({
+	currentDate,
+	hasCustomDate,
+	onRandomPoll,
+	onResetToToday,
+}: DevPollNavigatorUIProps) => (
+	<div className="max-w-5xl mx-auto mb-4 flex gap-2 items-center">
+		<button
+			type="button"
+			onClick={onRandomPoll}
+			className="px-3 py-1 text-xs bg-yellow-600 hover:bg-yellow-500 text-black rounded"
+		>
+			Random Poll
+		</button>
+		{hasCustomDate && (
+			<button
+				type="button"
+				onClick={onResetToToday}
+				className="px-3 py-1 text-xs bg-gray-600 hover:bg-gray-500 text-white rounded"
+			>
+				Today
+			</button>
+		)}
+		<span className="text-xs text-gray-500">Viewing: {currentDate}</span>
+	</div>
+);

--- a/src/ui/DevPollNavigatorUI.spec.tsx
+++ b/src/ui/DevPollNavigatorUI.spec.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DevPollNavigatorUI } from "./DevPollNavigatorUI.component";
+
+const defaultProps = {
+	currentDate: "2025-05-13",
+	hasCustomDate: false,
+	onRandomPoll: vi.fn(),
+	onResetToToday: vi.fn(),
+};
+
+describe("DevPollNavigatorUI", () => {
+	it("renders the current date", () => {
+		render(<DevPollNavigatorUI {...defaultProps} />);
+		expect(screen.getByText("Viewing: 2025-05-13")).toBeInTheDocument();
+	});
+
+	it("always renders the Random Poll button", () => {
+		render(<DevPollNavigatorUI {...defaultProps} />);
+		expect(
+			screen.getByRole("button", { name: "Random Poll" })
+		).toBeInTheDocument();
+	});
+
+	it("hides Today button when hasCustomDate is false", () => {
+		render(<DevPollNavigatorUI {...defaultProps} hasCustomDate={false} />);
+		expect(
+			screen.queryByRole("button", { name: "Today" })
+		).not.toBeInTheDocument();
+	});
+
+	it("shows Today button when hasCustomDate is true", () => {
+		render(<DevPollNavigatorUI {...defaultProps} hasCustomDate />);
+		expect(screen.getByRole("button", { name: "Today" })).toBeInTheDocument();
+	});
+
+	it("calls onRandomPoll when Random Poll is clicked", async () => {
+		const onRandomPoll = vi.fn();
+		render(
+			<DevPollNavigatorUI {...defaultProps} onRandomPoll={onRandomPoll} />
+		);
+		await userEvent.click(screen.getByRole("button", { name: "Random Poll" }));
+		expect(onRandomPoll).toHaveBeenCalledOnce();
+	});
+
+	it("calls onResetToToday when Today is clicked", async () => {
+		const onResetToToday = vi.fn();
+		render(
+			<DevPollNavigatorUI
+				{...defaultProps}
+				hasCustomDate
+				onResetToToday={onResetToToday}
+			/>
+		);
+		await userEvent.click(screen.getByRole("button", { name: "Today" }));
+		expect(onResetToToday).toHaveBeenCalledOnce();
+	});
+});

--- a/src/ui/DevPollNavigatorUI.stories.tsx
+++ b/src/ui/DevPollNavigatorUI.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { DevPollNavigatorUI } from "./DevPollNavigatorUI.component";
+
+const meta: Meta<typeof DevPollNavigatorUI> = {
+	component: DevPollNavigatorUI,
+	title: "UI/DevPollNavigatorUI",
+};
+export default meta;
+
+type Story = StoryObj<typeof DevPollNavigatorUI>;
+
+export const Default: Story = {
+	args: {
+		currentDate: "2025-05-13",
+		hasCustomDate: false,
+		onRandomPoll: () => {},
+		onResetToToday: () => {},
+	},
+};
+
+export const WithCustomDate: Story = {
+	args: {
+		currentDate: "2024-12-25",
+		hasCustomDate: true,
+		onRandomPoll: () => {},
+		onResetToToday: () => {},
+	},
+};

--- a/src/ui/Dropdown.spec.tsx
+++ b/src/ui/Dropdown.spec.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Dropdown, DropdownItem, DropdownDivider } from "./Dropdown.component";
+
+const TestDropdown = () => (
+	<Dropdown trigger={({ isOpen }) => <span>{isOpen ? "Close" : "Open"}</span>}>
+		{({ close }) => (
+			<>
+				<DropdownItem onClick={close}>Banjo</DropdownItem>
+				<DropdownDivider />
+				<DropdownItem variant="danger" onClick={close}>
+					Kazooie
+				</DropdownItem>
+			</>
+		)}
+	</Dropdown>
+);
+
+describe("Dropdown", () => {
+	it("does not show menu initially", () => {
+		render(<TestDropdown />);
+		expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+	});
+
+	it("opens menu on trigger click", async () => {
+		render(<TestDropdown />);
+		await userEvent.click(screen.getByRole("button"));
+		expect(screen.getByRole("menu")).toBeInTheDocument();
+		expect(screen.getByText("Banjo")).toBeInTheDocument();
+	});
+
+	it("closes menu when an item is clicked", async () => {
+		render(<TestDropdown />);
+		await userEvent.click(screen.getByRole("button"));
+		await userEvent.click(screen.getByRole("menuitem", { name: "Banjo" }));
+		expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+	});
+
+	it("closes menu on Escape key", async () => {
+		render(<TestDropdown />);
+		await userEvent.click(screen.getByRole("button"));
+		await userEvent.keyboard("{Escape}");
+		expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+	});
+});
+
+describe("DropdownItem", () => {
+	it("renders children", () => {
+		render(<DropdownItem>Pikachu</DropdownItem>);
+		expect(
+			screen.getByRole("menuitem", { name: "Pikachu" })
+		).toBeInTheDocument();
+	});
+
+	it("is disabled when disabled prop is set", () => {
+		render(<DropdownItem disabled>Locked</DropdownItem>);
+		expect(screen.getByRole("menuitem")).toBeDisabled();
+	});
+});

--- a/src/ui/Dropdown.stories.tsx
+++ b/src/ui/Dropdown.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Dropdown, DropdownItem, DropdownDivider } from "./Dropdown.component";
+
+const meta: Meta<typeof Dropdown> = {
+	component: Dropdown,
+	title: "UI/Dropdown",
+};
+export default meta;
+
+type Story = StoryObj<typeof Dropdown>;
+
+export const Default: Story = {
+	args: {
+		trigger: ({ isOpen }) => <span>{isOpen ? "▲ Menu" : "▼ Menu"}</span>,
+		children: ({ close }) => (
+			<>
+				<DropdownItem onClick={close}>View profile</DropdownItem>
+				<DropdownItem onClick={close}>Settings</DropdownItem>
+				<DropdownDivider />
+				<DropdownItem variant="danger" onClick={close}>
+					Sign out
+				</DropdownItem>
+			</>
+		),
+	},
+};
+
+export const AlignLeft: Story = {
+	args: {
+		align: "left",
+		trigger: () => <span>▼ Actions</span>,
+		children: ({ close }) => <DropdownItem onClick={close}>Open</DropdownItem>,
+	},
+};

--- a/src/ui/ErrorComponent.spec.tsx
+++ b/src/ui/ErrorComponent.spec.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ErrorComponent } from "./ErrorComponent.component";
+
+describe("ErrorComponent", () => {
+	it("renders the error text", () => {
+		render(<ErrorComponent text="Something went wrong." />);
+		expect(screen.getByText("Something went wrong.")).toBeInTheDocument();
+	});
+
+	it("renders a heading", () => {
+		render(<ErrorComponent text="Poll not found." />);
+		expect(
+			screen.getByRole("heading", { name: "Poll not found." })
+		).toBeInTheDocument();
+	});
+});

--- a/src/ui/ErrorComponent.stories.tsx
+++ b/src/ui/ErrorComponent.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ErrorComponent } from "./ErrorComponent.component";
+
+const meta: Meta<typeof ErrorComponent> = {
+	component: ErrorComponent,
+	title: "UI/ErrorComponent",
+};
+export default meta;
+
+type Story = StoryObj<typeof ErrorComponent>;
+
+export const Default: Story = {
+	args: { text: "Something went wrong. Please try again." },
+};
+
+export const NotFound: Story = {
+	args: { text: "Poll not found." },
+};

--- a/src/ui/FooterUI.component.tsx
+++ b/src/ui/FooterUI.component.tsx
@@ -1,0 +1,51 @@
+import { ReactNode } from "react";
+
+type FooterUIProps = {
+	pollCount: number | null;
+	isLoading: boolean;
+	categoryCount: number;
+	configCount: number;
+	lastCommitDate: string;
+	statsLink: ReactNode;
+};
+
+export const FooterUI = ({
+	pollCount,
+	isLoading,
+	categoryCount,
+	configCount,
+	lastCommitDate,
+	statsLink,
+}: FooterUIProps) => (
+	<footer className="p-4 mt-auto bg-zinc-900 text-white flex flex-col items-center">
+		<section className="flex gap-2 items-center">
+			{!isLoading && pollCount !== null && <div>{pollCount} polls</div>}
+			<span>·</span>
+			<div>{categoryCount} categories</div>
+			<span>·</span>
+			<div>{configCount} configs</div>
+			<span>·</span>
+			{statsLink}
+		</section>
+
+		<hr className="border-theme my-4" />
+		<section>
+			<p>
+				A crazy roguelike obsession build with craftsmanship, passion, ❤️ &
+				Tanstack Start by Marciano Schildmeijer | EST may 2022 | Last updated:{" "}
+				{lastCommitDate}
+			</p>
+			<p className="mt-2 text-zinc-400">
+				Found a bug?{" "}
+				<a
+					href="https://github.com/marcianosr/DevVoted/issues"
+					target="_blank"
+					rel="noopener noreferrer"
+					className="text-blue-400 hover:text-blue-300 underline"
+				>
+					Report it on GitHub
+				</a>
+			</p>
+		</section>
+	</footer>
+);

--- a/src/ui/FooterUI.spec.tsx
+++ b/src/ui/FooterUI.spec.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FooterUI } from "./FooterUI.component";
+
+const defaultProps = {
+	pollCount: 142,
+	isLoading: false,
+	categoryCount: 8,
+	configCount: 24,
+	lastCommitDate: "13 May 2025",
+	statsLink: <a href="/stats">Stats</a>,
+};
+
+describe("FooterUI", () => {
+	it("shows poll count when loaded", () => {
+		render(<FooterUI {...defaultProps} />);
+		expect(screen.getByText("142 polls")).toBeInTheDocument();
+	});
+
+	it("hides poll count when loading", () => {
+		render(<FooterUI {...defaultProps} isLoading pollCount={null} />);
+		expect(screen.queryByText(/polls/)).not.toBeInTheDocument();
+	});
+
+	it("shows category and config counts", () => {
+		render(<FooterUI {...defaultProps} />);
+		expect(screen.getByText("8 categories")).toBeInTheDocument();
+		expect(screen.getByText("24 configs")).toBeInTheDocument();
+	});
+
+	it("shows the last commit date", () => {
+		render(<FooterUI {...defaultProps} />);
+		expect(screen.getByText(/13 May 2025/)).toBeInTheDocument();
+	});
+
+	it("renders the stats link slot", () => {
+		render(<FooterUI {...defaultProps} />);
+		expect(screen.getByRole("link", { name: "Stats" })).toBeInTheDocument();
+	});
+
+	it("renders the GitHub bug report link", () => {
+		render(<FooterUI {...defaultProps} />);
+		expect(
+			screen.getByRole("link", { name: "Report it on GitHub" })
+		).toBeInTheDocument();
+	});
+});

--- a/src/ui/FooterUI.stories.tsx
+++ b/src/ui/FooterUI.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { FooterUI } from "./FooterUI.component";
+
+const meta: Meta<typeof FooterUI> = {
+	component: FooterUI,
+	title: "UI/FooterUI",
+};
+export default meta;
+
+type Story = StoryObj<typeof FooterUI>;
+
+export const Loaded: Story = {
+	args: {
+		pollCount: 142,
+		isLoading: false,
+		categoryCount: 8,
+		configCount: 24,
+		lastCommitDate: "13 May 2025",
+		statsLink: (
+			<a href="/stats" className="underline">
+				See all game info stats
+			</a>
+		),
+	},
+};
+
+export const Loading: Story = {
+	args: {
+		pollCount: null,
+		isLoading: true,
+		categoryCount: 8,
+		configCount: 24,
+		lastCommitDate: "25 Dec 2024",
+		statsLink: (
+			<a href="/stats" className="underline">
+				See all game info stats
+			</a>
+		),
+	},
+};

--- a/src/ui/GameLoopExplainer.spec.tsx
+++ b/src/ui/GameLoopExplainer.spec.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GameLoopExplainer } from "./GameLoopExplainer.component";
+
+describe("GameLoopExplainer", () => {
+	it("renders the first step by default", () => {
+		render(<GameLoopExplainer />);
+		expect(screen.getByText("Answer Polls")).toBeInTheDocument();
+	});
+
+	it("Previous button is disabled on the first step", () => {
+		render(<GameLoopExplainer />);
+		expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
+	});
+
+	it("advances to the next step on Next click", async () => {
+		render(<GameLoopExplainer />);
+		await userEvent.click(screen.getByRole("button", { name: "Next" }));
+		expect(screen.getByText("Build Coverage")).toBeInTheDocument();
+	});
+
+	it("Previous button is enabled after advancing", async () => {
+		render(<GameLoopExplainer />);
+		await userEvent.click(screen.getByRole("button", { name: "Next" }));
+		expect(screen.getByRole("button", { name: "Previous" })).not.toBeDisabled();
+	});
+
+	it("Next button is disabled on the last step", async () => {
+		render(<GameLoopExplainer />);
+		for (let i = 0; i < 4; i++) {
+			await userEvent.click(screen.getByRole("button", { name: "Next" }));
+		}
+		expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
+	});
+
+	it("dot navigation jumps to a specific step", async () => {
+		render(<GameLoopExplainer />);
+		await userEvent.click(screen.getByRole("button", { name: "Go to step 4" }));
+		expect(screen.getByText("Upgrade Your Pipeline")).toBeInTheDocument();
+	});
+});

--- a/src/ui/GameLoopExplainer.stories.tsx
+++ b/src/ui/GameLoopExplainer.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { GameLoopExplainer } from "./GameLoopExplainer.component";
+
+const meta: Meta<typeof GameLoopExplainer> = {
+	component: GameLoopExplainer,
+	title: "UI/GameLoopExplainer",
+};
+export default meta;
+
+type Story = StoryObj<typeof GameLoopExplainer>;
+
+export const Default: Story = {};

--- a/src/ui/LoadingSkeleton.spec.tsx
+++ b/src/ui/LoadingSkeleton.spec.tsx
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { LoadingSkeleton } from "./LoadingSkeleton.component";
+
+describe("LoadingSkeleton", () => {
+	it("renders an animated pulse container", () => {
+		const { container: c } = render(<LoadingSkeleton />);
+		expect(c.querySelector(".animate-pulse")).toBeInTheDocument();
+	});
+});

--- a/src/ui/LoadingSkeleton.stories.tsx
+++ b/src/ui/LoadingSkeleton.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { LoadingSkeleton } from "./LoadingSkeleton.component";
+
+const meta: Meta<typeof LoadingSkeleton> = {
+	component: LoadingSkeleton,
+	title: "UI/LoadingSkeleton",
+};
+export default meta;
+
+type Story = StoryObj<typeof LoadingSkeleton>;
+
+export const Default: Story = {};

--- a/src/ui/NotFoundUI.component.tsx
+++ b/src/ui/NotFoundUI.component.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from "react";
+
+type NotFoundUIProps = {
+	onGoBack: () => void;
+	homeLink: ReactNode;
+	children?: ReactNode;
+};
+
+export const NotFoundUI = ({
+	onGoBack,
+	homeLink,
+	children,
+}: NotFoundUIProps) => (
+	<div className="space-y-2 p-2">
+		<div className="text-gray-600 dark:text-gray-400">
+			{children ?? <p>The page you are looking for does not exist.</p>}
+		</div>
+		<p className="flex items-center gap-2 flex-wrap">
+			<button
+				onClick={onGoBack}
+				className="bg-emerald-500 text-white px-2 py-1 rounded uppercase font-black text-sm"
+			>
+				Go back
+			</button>
+			{homeLink}
+		</p>
+	</div>
+);

--- a/src/ui/NotFoundUI.spec.tsx
+++ b/src/ui/NotFoundUI.spec.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NotFoundUI } from "./NotFoundUI.component";
+
+describe("NotFoundUI", () => {
+	it("renders default message when no children provided", () => {
+		render(<NotFoundUI onGoBack={() => {}} homeLink={<a href="/">Home</a>} />);
+		expect(
+			screen.getByText("The page you are looking for does not exist.")
+		).toBeInTheDocument();
+	});
+
+	it("renders custom children instead of default message", () => {
+		render(
+			<NotFoundUI onGoBack={() => {}} homeLink={<a href="/">Home</a>}>
+				<p>This run is gone.</p>
+			</NotFoundUI>
+		);
+		expect(screen.getByText("This run is gone.")).toBeInTheDocument();
+		expect(
+			screen.queryByText("The page you are looking for does not exist.")
+		).not.toBeInTheDocument();
+	});
+
+	it("calls onGoBack when Go back button is clicked", async () => {
+		const onGoBack = vi.fn();
+		render(<NotFoundUI onGoBack={onGoBack} homeLink={<a href="/">Home</a>} />);
+		await userEvent.click(screen.getByRole("button", { name: "Go back" }));
+		expect(onGoBack).toHaveBeenCalledOnce();
+	});
+
+	it("renders the home link slot", () => {
+		render(
+			<NotFoundUI onGoBack={() => {}} homeLink={<a href="/">Start Over</a>} />
+		);
+		expect(
+			screen.getByRole("link", { name: "Start Over" })
+		).toBeInTheDocument();
+	});
+});

--- a/src/ui/NotFoundUI.stories.tsx
+++ b/src/ui/NotFoundUI.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { NotFoundUI } from "./NotFoundUI.component";
+
+const meta: Meta<typeof NotFoundUI> = {
+	component: NotFoundUI,
+	title: "UI/NotFoundUI",
+};
+export default meta;
+
+type Story = StoryObj<typeof NotFoundUI>;
+
+export const Default: Story = {
+	args: {
+		onGoBack: () => {},
+		homeLink: (
+			<a
+				href="/"
+				className="bg-cyan-600 text-white px-2 py-1 rounded uppercase font-black text-sm"
+			>
+				Start Over
+			</a>
+		),
+	},
+};
+
+export const WithCustomMessage: Story = {
+	args: {
+		onGoBack: () => {},
+		homeLink: <a href="/">Home</a>,
+		children: <p>This run no longer exists.</p>,
+	},
+};

--- a/src/ui/PageLayoutUI.component.tsx
+++ b/src/ui/PageLayoutUI.component.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from "react";
+
+type PageLayoutUIProps = {
+	footer: ReactNode;
+	children: ReactNode;
+};
+
+export const PageLayoutUI = ({ footer, children }: PageLayoutUIProps) => (
+	<main className="flex flex-col min-h-screen pb-24">
+		{children}
+		{footer}
+	</main>
+);

--- a/src/ui/PageLayoutUI.spec.tsx
+++ b/src/ui/PageLayoutUI.spec.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PageLayoutUI } from "./PageLayoutUI.component";
+
+describe("PageLayoutUI", () => {
+	it("renders children", () => {
+		render(
+			<PageLayoutUI footer={<div>Footer</div>}>Page content</PageLayoutUI>
+		);
+		expect(screen.getByText("Page content")).toBeInTheDocument();
+	});
+
+	it("renders the footer slot", () => {
+		render(<PageLayoutUI footer={<div>My Footer</div>}>Content</PageLayoutUI>);
+		expect(screen.getByText("My Footer")).toBeInTheDocument();
+	});
+
+	it("wraps content in a main element", () => {
+		const { container } = render(
+			<PageLayoutUI footer={<div />}>Content</PageLayoutUI>
+		);
+		expect(container.querySelector("main")).toBeInTheDocument();
+	});
+});

--- a/src/ui/PageLayoutUI.stories.tsx
+++ b/src/ui/PageLayoutUI.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { PageLayoutUI } from "./PageLayoutUI.component";
+
+const meta: Meta<typeof PageLayoutUI> = {
+	component: PageLayoutUI,
+	title: "UI/PageLayoutUI",
+};
+export default meta;
+
+type Story = StoryObj<typeof PageLayoutUI>;
+
+export const Default: Story = {
+	args: {
+		footer: (
+			<footer className="p-4 bg-zinc-900 text-white text-center">Footer</footer>
+		),
+		children: <div className="p-8">Page content</div>,
+	},
+};

--- a/src/ui/Popover.spec.tsx
+++ b/src/ui/Popover.spec.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Popover } from "./Popover.component";
+
+// jsdom does not implement the native Popover API
+beforeAll(() => {
+	HTMLElement.prototype.showPopover = vi.fn();
+	HTMLElement.prototype.hidePopover = vi.fn();
+});
+
+const TestPopover = () => (
+	<Popover ariaLabel="Show info" content={<p>Rare game info</p>}>
+		<span>ℹ️</span>
+	</Popover>
+);
+
+describe("Popover", () => {
+	it("renders the trigger button", () => {
+		render(<TestPopover />);
+		expect(
+			screen.getByRole("button", { name: "Show info" })
+		).toBeInTheDocument();
+	});
+
+	it("trigger has aria-expanded=false initially", () => {
+		render(<TestPopover />);
+		expect(screen.getByRole("button")).toHaveAttribute(
+			"aria-expanded",
+			"false"
+		);
+	});
+
+	it("sets aria-expanded=true after click", async () => {
+		render(<TestPopover />);
+		await userEvent.click(screen.getByRole("button", { name: "Show info" }));
+		expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "true");
+	});
+
+	it("toggles closed on second click", async () => {
+		render(<TestPopover />);
+		const btn = screen.getByRole("button", { name: "Show info" });
+		await userEvent.click(btn);
+		await userEvent.click(btn);
+		expect(btn).toHaveAttribute("aria-expanded", "false");
+	});
+});

--- a/src/ui/Popover.stories.tsx
+++ b/src/ui/Popover.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Popover } from "./Popover.component";
+
+const meta: Meta<typeof Popover> = {
+	component: Popover,
+	title: "UI/Popover",
+};
+export default meta;
+
+type Story = StoryObj<typeof Popover>;
+
+export const Default: Story = {
+	args: {
+		ariaLabel: "Show info",
+		content: <p>Banjo-Kazooie is a platformer developed by Rare.</p>,
+		children: <span>ℹ️</span>,
+	},
+};
+
+export const WithLongContent: Story = {
+	args: {
+		ariaLabel: "Show storage info",
+		content: (
+			<div>
+				<p>Storage is used to install configs.</p>
+				<p>Each config uses a different amount of storage.</p>
+			</div>
+		),
+		children: <span>💾</span>,
+	},
+};

--- a/src/ui/PrimaryButton.spec.tsx
+++ b/src/ui/PrimaryButton.spec.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PrimaryButton } from "./PrimaryButton.component";
+
+describe("PrimaryButton", () => {
+	it("renders children", () => {
+		render(<PrimaryButton>Start Run</PrimaryButton>);
+		expect(
+			screen.getByRole("button", { name: "Start Run" })
+		).toBeInTheDocument();
+	});
+
+	it("is disabled when disabled prop is set", () => {
+		render(<PrimaryButton disabled>Start Run</PrimaryButton>);
+		expect(screen.getByRole("button")).toBeDisabled();
+	});
+
+	it("is disabled when isLoading", () => {
+		render(<PrimaryButton isLoading>Saving…</PrimaryButton>);
+		expect(screen.getByRole("button")).toBeDisabled();
+	});
+
+	it("applies small size class", () => {
+		render(<PrimaryButton size="small">Click</PrimaryButton>);
+		expect(screen.getByRole("button")).toHaveClass("text-sm");
+	});
+});

--- a/src/ui/PrimaryButton.stories.tsx
+++ b/src/ui/PrimaryButton.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { PrimaryButton } from "./PrimaryButton.component";
+
+const meta: Meta<typeof PrimaryButton> = {
+	component: PrimaryButton,
+	title: "UI/PrimaryButton",
+};
+export default meta;
+
+type Story = StoryObj<typeof PrimaryButton>;
+
+export const Default: Story = {
+	args: { children: "Start Run" },
+};
+
+export const Small: Story = {
+	args: { children: "Confirm", size: "small" },
+};
+
+export const Loading: Story = {
+	args: { children: "Saving…", isLoading: true },
+};
+
+export const Disabled: Story = {
+	args: { children: "Unavailable", disabled: true },
+};

--- a/src/ui/SecondaryButton.spec.tsx
+++ b/src/ui/SecondaryButton.spec.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SecondaryButton } from "./SecondaryButton.component";
+
+describe("SecondaryButton", () => {
+	it("renders children", () => {
+		render(<SecondaryButton>Cancel</SecondaryButton>);
+		expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+	});
+
+	it("is disabled when disabled prop is set", () => {
+		render(<SecondaryButton disabled>Cancel</SecondaryButton>);
+		expect(screen.getByRole("button")).toBeDisabled();
+	});
+
+	it("is disabled when isLoading", () => {
+		render(<SecondaryButton isLoading>Saving…</SecondaryButton>);
+		expect(screen.getByRole("button")).toBeDisabled();
+	});
+
+	it("applies danger variant styles", () => {
+		render(<SecondaryButton variant="danger">Delete</SecondaryButton>);
+		expect(screen.getByRole("button")).toHaveClass("border-red-500");
+	});
+});

--- a/src/ui/SecondaryButton.stories.tsx
+++ b/src/ui/SecondaryButton.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SecondaryButton } from "./SecondaryButton.component";
+
+const meta: Meta<typeof SecondaryButton> = {
+	component: SecondaryButton,
+	title: "UI/SecondaryButton",
+};
+export default meta;
+
+type Story = StoryObj<typeof SecondaryButton>;
+
+export const Default: Story = {
+	args: { children: "Cancel" },
+};
+
+export const Danger: Story = {
+	args: { children: "Delete", variant: "danger" },
+};
+
+export const Loading: Story = {
+	args: { children: "Saving…", isLoading: true },
+};
+
+export const Disabled: Story = {
+	args: { children: "Unavailable", disabled: true },
+};

--- a/src/ui/TextButton.spec.tsx
+++ b/src/ui/TextButton.spec.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TextButton } from "./TextButton.component";
+
+describe("TextButton", () => {
+	it("renders children wrapped in brackets", () => {
+		render(<TextButton>View details</TextButton>);
+		expect(
+			screen.getByRole("button", { name: "[ View details ]" })
+		).toBeInTheDocument();
+	});
+
+	it("is disabled when disabled prop is set", () => {
+		render(<TextButton disabled>Locked</TextButton>);
+		expect(screen.getByRole("button")).toBeDisabled();
+	});
+
+	it("applies success variant styles by default", () => {
+		render(<TextButton>Action</TextButton>);
+		expect(screen.getByRole("button")).toHaveClass("text-green-500");
+	});
+
+	it("applies danger variant styles", () => {
+		render(<TextButton variant="danger">Remove</TextButton>);
+		expect(screen.getByRole("button")).toHaveClass("text-red-500");
+	});
+});

--- a/src/ui/TextButton.stories.tsx
+++ b/src/ui/TextButton.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { TextButton } from "./TextButton.component";
+
+const meta: Meta<typeof TextButton> = {
+	component: TextButton,
+	title: "UI/TextButton",
+};
+export default meta;
+
+type Story = StoryObj<typeof TextButton>;
+
+export const Success: Story = {
+	args: { children: "View details", variant: "success" },
+};
+
+export const Danger: Story = {
+	args: { children: "Remove", variant: "danger" },
+};
+
+export const Disabled: Story = {
+	args: { children: "Locked", disabled: true },
+};

--- a/supabase/migrations/20251107000000_add_performance_indexes.sql
+++ b/supabase/migrations/20251107000000_add_performance_indexes.sql
@@ -1,157 +1,107 @@
 -- Migration: Add Performance Indexes
 -- Description: Adds critical and high-priority indexes to improve query performance
 -- Date: 2025-11-07
-
--- ============================================================================
--- PHASE 1: CRITICAL PRIORITY INDEXES
--- These indexes address the most severe performance bottlenecks
--- Expected impact: 50-90% query time reduction on affected queries
--- ============================================================================
-
--- Index 1: polls_responses composite index
--- Covers the most common query pattern: filtering by poll_id and user_id
--- Used in: hasUserAnsweredPoll(), countUserPollAnswers(), getUserPollStats()
-CREATE INDEX IF NOT EXISTS idx_polls_responses_poll_user_created
-ON polls_responses(poll_id, user_id, created_at);
-
--- Index 2: runs user and status lookup
--- Critical for finding active runs and last finished runs
--- Used in: getActiveRunByUserId(), getLastRunFromUser()
-CREATE INDEX IF NOT EXISTS idx_runs_user_status
-ON runs(user_id, status);
-
--- Index 3: runs finished timestamp
--- Optimizes ordering by finish time for completed runs
--- Used in: getLastRunFromUser() with ORDER BY finished_at DESC
-CREATE INDEX IF NOT EXISTS idx_runs_finished_at
-ON runs(finished_at DESC) WHERE status = 'finished';
-
--- Index 4: run_category_coverage by run_id
--- Used in virtually every run-related query (10+ call sites)
--- Used in: getTotalCoverageForRun(), getTotalPollsAnsweredForRun(), getBestStreakForRun()
-CREATE INDEX IF NOT EXISTS idx_run_category_coverage_run_id
-ON run_category_coverage(run_id);
-
--- Index 5: polls_options by poll_id
--- Essential for fetching poll options (one-to-many relationship)
--- Used in: fetchPollByIdWithOptions() - called on every poll answer
-CREATE INDEX IF NOT EXISTS idx_polls_options_poll_id
-ON polls_options(poll_id);
-
--- Index 6: polls_history by user_id
--- Frequently accessed for tracking user poll viewing history
--- Used in: getPollHistory(), getTotalPollsSeenByUser()
-CREATE INDEX IF NOT EXISTS idx_polls_history_user_id
-ON polls_history(user_id);
-
-
--- ============================================================================
--- PHASE 2: HIGH PRIORITY INDEXES
--- Foreign keys and frequently queried columns
--- Expected impact: 30-70% query time reduction
--- ============================================================================
-
--- Leaderboard indexes (critical for ranking queries)
--- Used in: buildLeaderboardQuery(), getCategoryLeaderboard()
-CREATE INDEX IF NOT EXISTS idx_leaderboard_user_id
-ON leaderboard(user_id);
-
-CREATE INDEX IF NOT EXISTS idx_leaderboard_season_id
-ON leaderboard(season_id);
-
-CREATE INDEX IF NOT EXISTS idx_leaderboard_category_code
-ON leaderboard(category_code);
-
--- Composite leaderboard lookup for filtered queries
-CREATE INDEX IF NOT EXISTS idx_leaderboard_lookup
-ON leaderboard(season_id, category_code, user_id);
-
--- Polls filtering indexes
--- Used in: manageDailyPollTransition(), category filtering
-CREATE INDEX IF NOT EXISTS idx_polls_status
-ON polls(status);
-
-CREATE INDEX IF NOT EXISTS idx_polls_category_code
-ON polls(category_code);
-
--- polls_response_options join table indexes
--- Used when fetching response details and selected options
-CREATE INDEX IF NOT EXISTS idx_polls_response_options_response_id
-ON polls_response_options(response_id);
-
-CREATE INDEX IF NOT EXISTS idx_polls_response_options_option_id
-ON polls_response_options(option_id);
-
--- Run category coverage by category
--- Used in: getLiveRunRankings() when filtering by category
-CREATE INDEX IF NOT EXISTS idx_run_category_coverage_category
-ON run_category_coverage(category_code);
-
--- Runs season lookup
--- Foreign key to seasons table
-CREATE INDEX IF NOT EXISTS idx_runs_season_id
-ON runs(season_id);
-
-
--- ============================================================================
--- PHASE 3: MEDIUM PRIORITY INDEXES
--- Performance optimizations and foreign keys
--- Expected impact: 15-40% query time reduction
--- ============================================================================
-
--- Polls creator lookup
--- Useful for admin queries to find polls by creator
-CREATE INDEX IF NOT EXISTS idx_polls_created_by
-ON polls(created_by);
-
--- polls_responses timestamp index
--- Used in: hasUserAnsweredPoll() with date range filtering
-CREATE INDEX IF NOT EXISTS idx_polls_responses_created_at
-ON polls_responses(created_at);
-
--- Seasons status and date range indexes
--- Used in: findActiveSeasons(), findCurrentSeason()
-CREATE INDEX IF NOT EXISTS idx_seasons_status
-ON seasons(status);
-
-CREATE INDEX IF NOT EXISTS idx_seasons_dates
-ON seasons(start_date, end_date);
-
--- Polls creation timestamp
--- Used in: fetchAllPolls() ORDER BY created_at
-CREATE INDEX IF NOT EXISTS idx_polls_created_at
-ON polls(created_at DESC);
-
-
--- ============================================================================
--- STATISTICS UPDATE
--- Refresh table statistics for query planner
--- ============================================================================
-
-ANALYZE polls;
-ANALYZE polls_options;
-ANALYZE polls_responses;
-ANALYZE polls_response_options;
-ANALYZE polls_history;
-ANALYZE runs;
-ANALYZE run_category_coverage;
-ANALYZE leaderboard;
-ANALYZE seasons;
-
-
--- ============================================================================
--- MIGRATION NOTES
--- ============================================================================
--- Total indexes added: 22
 --
--- Performance monitoring recommendations:
--- 1. Track query execution times before/after migration
--- 2. Monitor index usage: SELECT * FROM pg_stat_user_indexes;
--- 3. Check for unused indexes after 1 week
--- 4. Verify no index bloat: SELECT * FROM pg_indexes WHERE schemaname = 'public';
---
--- Estimated storage impact: 10-20% increase in database size
--- Estimated write performance impact: Minimal (tables are read-heavy)
---
--- Rollback: DROP INDEX statements for each index if needed
--- ============================================================================
+-- Wrapped in a DO block so this is safe to run before the Drizzle schema
+-- is initialised (e.g. on a fresh local Supabase start). Indexes are
+-- created only when the base tables already exist.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT FROM pg_tables WHERE schemaname = 'public' AND tablename = 'polls'
+  ) THEN
+    RAISE NOTICE 'Base schema not yet initialised — skipping performance indexes migration';
+    RETURN;
+  END IF;
+
+  -- ============================================================================
+  -- PHASE 1: CRITICAL PRIORITY INDEXES
+  -- ============================================================================
+
+  CREATE INDEX IF NOT EXISTS idx_polls_responses_poll_user_created
+    ON polls_responses(poll_id, user_id, created_at);
+
+  CREATE INDEX IF NOT EXISTS idx_runs_user_status
+    ON runs(user_id, status);
+
+  CREATE INDEX IF NOT EXISTS idx_runs_finished_at
+    ON runs(finished_at DESC) WHERE status = 'finished';
+
+  CREATE INDEX IF NOT EXISTS idx_run_category_coverage_run_id
+    ON run_category_coverage(run_id);
+
+  CREATE INDEX IF NOT EXISTS idx_polls_options_poll_id
+    ON polls_options(poll_id);
+
+  CREATE INDEX IF NOT EXISTS idx_polls_history_user_id
+    ON polls_history(user_id);
+
+  -- ============================================================================
+  -- PHASE 2: HIGH PRIORITY INDEXES
+  -- ============================================================================
+
+  CREATE INDEX IF NOT EXISTS idx_leaderboard_user_id
+    ON leaderboard(user_id);
+
+  CREATE INDEX IF NOT EXISTS idx_leaderboard_season_id
+    ON leaderboard(season_id);
+
+  CREATE INDEX IF NOT EXISTS idx_leaderboard_category_code
+    ON leaderboard(category_code);
+
+  CREATE INDEX IF NOT EXISTS idx_leaderboard_lookup
+    ON leaderboard(season_id, category_code, user_id);
+
+  CREATE INDEX IF NOT EXISTS idx_polls_status
+    ON polls(status);
+
+  CREATE INDEX IF NOT EXISTS idx_polls_category_code
+    ON polls(category_code);
+
+  CREATE INDEX IF NOT EXISTS idx_polls_response_options_response_id
+    ON polls_response_options(response_id);
+
+  CREATE INDEX IF NOT EXISTS idx_polls_response_options_option_id
+    ON polls_response_options(option_id);
+
+  CREATE INDEX IF NOT EXISTS idx_run_category_coverage_category
+    ON run_category_coverage(category_code);
+
+  CREATE INDEX IF NOT EXISTS idx_runs_season_id
+    ON runs(season_id);
+
+  -- ============================================================================
+  -- PHASE 3: MEDIUM PRIORITY INDEXES
+  -- ============================================================================
+
+  CREATE INDEX IF NOT EXISTS idx_polls_created_by
+    ON polls(created_by);
+
+  CREATE INDEX IF NOT EXISTS idx_polls_responses_created_at
+    ON polls_responses(created_at);
+
+  CREATE INDEX IF NOT EXISTS idx_seasons_status
+    ON seasons(status);
+
+  CREATE INDEX IF NOT EXISTS idx_seasons_dates
+    ON seasons(start_date, end_date);
+
+  CREATE INDEX IF NOT EXISTS idx_polls_created_at
+    ON polls(created_at DESC);
+
+  -- ============================================================================
+  -- STATISTICS UPDATE
+  -- ============================================================================
+
+  ANALYZE polls;
+  ANALYZE polls_options;
+  ANALYZE polls_responses;
+  ANALYZE polls_response_options;
+  ANALYZE polls_history;
+  ANALYZE runs;
+  ANALYZE run_category_coverage;
+  ANALYZE leaderboard;
+  ANALYZE seasons;
+
+END $$;

--- a/supabase/migrations/20251203120000_add_missing_columns.sql
+++ b/supabase/migrations/20251203120000_add_missing_columns.sql
@@ -1,4 +1,16 @@
 -- Add missing columns to sync with Drizzle schema
-ALTER TABLE "polls" ADD COLUMN IF NOT EXISTS "explanation" text;
-ALTER TABLE "runs" ADD COLUMN IF NOT EXISTS "shop_skipped_date" varchar(10);
-ALTER TABLE "runs" ADD COLUMN IF NOT EXISTS "shop_interacted_date" varchar(10);
+-- Wrapped in a guard so this is safe to run before the Drizzle schema exists.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT FROM pg_tables WHERE schemaname = 'public' AND tablename = 'polls'
+  ) THEN
+    RAISE NOTICE 'Base schema not yet initialised — skipping add_missing_columns migration';
+    RETURN;
+  END IF;
+
+  ALTER TABLE "polls" ADD COLUMN IF NOT EXISTS "explanation" text;
+  ALTER TABLE "runs" ADD COLUMN IF NOT EXISTS "shop_skipped_date" varchar(10);
+  ALTER TABLE "runs" ADD COLUMN IF NOT EXISTS "shop_interacted_date" varchar(10);
+END $$;

--- a/supabase/migrations/20251204120000_add_daily_polls_table.sql
+++ b/supabase/migrations/20251204120000_add_daily_polls_table.sql
@@ -1,27 +1,32 @@
 -- Create daily_polls table for O(1) daily poll lookups
 -- This replaces the expensive manageDailyPollTransition that fetched all polls
+-- Wrapped in a guard so this is safe to run before the Drizzle schema exists.
 
-CREATE TABLE IF NOT EXISTS "daily_polls" (
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT FROM pg_tables WHERE schemaname = 'public' AND tablename = 'polls'
+  ) THEN
+    RAISE NOTICE 'Base schema not yet initialised — skipping add_daily_polls_table migration';
+    RETURN;
+  END IF;
+
+  CREATE TABLE IF NOT EXISTS "daily_polls" (
     "id" serial PRIMARY KEY,
     "date" varchar(10) NOT NULL UNIQUE,
     "poll_id" integer NOT NULL REFERENCES "polls"("id") ON DELETE CASCADE,
     "created_at" timestamp with time zone DEFAULT now()
-);
+  );
 
--- Create unique index on date for fast lookups
-CREATE UNIQUE INDEX IF NOT EXISTS "idx_daily_polls_date" ON "daily_polls"("date");
+  CREATE UNIQUE INDEX IF NOT EXISTS "idx_daily_polls_date" ON "daily_polls"("date");
 
--- Migrate current open poll to daily_polls (if any exists)
-INSERT INTO "daily_polls" ("date", "poll_id")
-SELECT
+  -- Migrate current open poll to daily_polls (if any exists)
+  INSERT INTO "daily_polls" ("date", "poll_id")
+  SELECT
     to_char(CURRENT_DATE, 'YYYY-MM-DD'),
     "id"
-FROM "polls"
-WHERE "status" = 'open'
-LIMIT 1
-ON CONFLICT ("date") DO NOTHING;
-
--- Remove status column from polls (keep for now, will deprecate)
--- ALTER TABLE "polls" DROP COLUMN IF EXISTS "status";
--- Note: Keeping status column for now to support gradual migration
--- Can be removed in a future migration once all code is updated
+  FROM "polls"
+  WHERE "status" = 'open'
+  LIMIT 1
+  ON CONFLICT ("date") DO NOTHING;
+END $$;

--- a/supabase/migrations/20251214120000_add_challenge_mode_id.sql
+++ b/supabase/migrations/20251214120000_add_challenge_mode_id.sql
@@ -1,1 +1,12 @@
-ALTER TABLE "runs" ADD COLUMN "challenge_mode_id" varchar(50);
+-- Wrapped in a guard so this is safe to run before the Drizzle schema exists.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT FROM pg_tables WHERE schemaname = 'public' AND tablename = 'runs'
+  ) THEN
+    RAISE NOTICE 'Base schema not yet initialised — skipping add_challenge_mode_id migration';
+    RETURN;
+  END IF;
+
+  ALTER TABLE "runs" ADD COLUMN IF NOT EXISTS "challenge_mode_id" varchar(50);
+END $$;

--- a/supabase/migrations/20251216120000_add_deinstall_penalty.sql
+++ b/supabase/migrations/20251216120000_add_deinstall_penalty.sql
@@ -1,1 +1,12 @@
-ALTER TABLE "runs" ADD COLUMN "deinstall_penalty" integer DEFAULT 0 NOT NULL;
+-- Wrapped in a guard so this is safe to run before the Drizzle schema exists.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT FROM pg_tables WHERE schemaname = 'public' AND tablename = 'runs'
+  ) THEN
+    RAISE NOTICE 'Base schema not yet initialised — skipping add_deinstall_penalty migration';
+    RETURN;
+  END IF;
+
+  ALTER TABLE "runs" ADD COLUMN IF NOT EXISTS "deinstall_penalty" integer DEFAULT 0 NOT NULL;
+END $$;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,11 @@
 {
 	"include": ["**/*.ts", "**/*.tsx"],
-	"exclude": ["src/database/seed.ts", "src/database/reset.ts"],
+	"exclude": [
+		"src/database/seed.ts",
+		"src/database/reset.ts",
+		".storybook",
+		"**/*.stories.tsx"
+	],
 	"compilerOptions": {
 		"strict": true,
 		"esModuleInterop": true,


### PR DESCRIPTION
## Summary

- **Storybook setup**: Installs Storybook 10 (Vite + React, Tailwind v4, dark mode by default with toolbar toggle)
- **Two-tier UI architecture**: All HTML/CSS extracted from composition components into presentational UI primitives in \`src/ui/\` and \`src/ui/{domain}/\`
- **Atomic Storybook structure**: Stories reorganised into Atoms / Molecules / Organisms / Templates / Pages hierarchy, with domain components grouped under their domain (e.g. \`Ranking/Organisms/Leaderboard\`)
- **Storybook background fix**: Added \`@custom-variant dark\` to Tailwind config so the \`.dark\` class (set by Storybook's theme toolbar) correctly activates dark-mode utilities — matching the live app's black/white colour scheme
- **Ranking domain refactor**: \`SeasonInfo\` and \`Leaderboard\` fully split — UI components in \`src/ui/ranking/\`, composition components in \`src/domains/ranking/components/\` with zero HTML/CSS
- **New game UI components in Storybook**: Pipeline display, gate health, config cards, shop cards, and storage breakdown — all in \`src/ui/economy/\` and \`src/ui/runs/\` with rich story variants

## Architecture

**Tier 1 — Presentational** (\`src/ui/\`, \`src/ui/{domain}/\`): pure HTML + Tailwind, plain props only, no hooks or server functions, fully renderable from Storybook without a running server.

**Tier 2 — Composition** (\`src/domains/*/components/\`, \`src/routes/\`): zero HTML/CSS, wires data and mutations into Tier 1 components via props.

## UI components with Storybook stories

**Global primitives** (\`src/ui/\`):
- Atoms: \`PrimaryButton\`, \`SecondaryButton\`, \`TextButton\`, \`LoadingSkeleton\`, \`ContentSection\`
- Molecules: \`Dropdown\`, \`Popover\`, \`ConfirmDialog\`, \`DevPollNavigatorUI\`
- Organisms: \`FooterUI\`, \`GameLoopExplainer\`
- Templates: \`PageLayoutUI\`
- Pages: \`NotFoundUI\`, \`ErrorComponent\`, \`CatchBoundaryUI\`

**Ranking** (\`src/ui/ranking/\`):
- \`SeasonInfo\` — atom showing season name and days remaining
- \`LeaderboardUI\` — organism with sortable player grid, loading and error states

**Economy** (\`src/ui/economy/\`):
- \`ConfigCard\` — all 4 rarities (common → legendary) with Kanto-palette colour theming, small/large sizes
- \`ShopCard\` — card + install button, states: available / installed / can't afford / shop closed
- \`StorageBreakdown\` — usage bar + breakdown, with recent-gain animation support

**Runs** (\`src/ui/runs/\`):
- \`PipelineDisplay\` — slot list with in-progress / passed / failed / skipped states, polls-remaining counter, evaluation result
- \`GateHealth\` — gate number, polls left, per-slot status with live current-stat readout

## Test plan

- [ ] \`npm test\` passes
- [ ] \`npm run build\` succeeds
- [ ] \`npm run storybook\` — dark background, all stories visible under atomic hierarchy
- [ ] Theme toggle in Storybook toolbar switches between dark (black) and light correctly
- [ ] Ranking page (\`/stats\` leaderboard) renders as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)