### PR TITLE
feat: UI layer extraction Phase 3 — domain components to ui/ tier

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,9 +1,16 @@
-import type { Preview } from "@storybook/react";
+import type { Preview, Renderer, StoryFn } from "@storybook/react";
 import { withThemeByClassName } from "@storybook/addon-themes";
 import "../src/styles/app.css";
 
+const withAppBackground = (Story: StoryFn<Renderer>) => (
+	<div className="min-h-screen bg-gray-50 dark:bg-black text-gray-900 dark:text-white p-4">
+		<Story />
+	</div>
+);
+
 const preview: Preview = {
 	decorators: [
+		withAppBackground,
 		withThemeByClassName({
 			themes: {
 				dark: "dark",

--- a/src/database/seed.ts
+++ b/src/database/seed.ts
@@ -28,6 +28,33 @@ const ADMIN_UID = "65ad226e-e3c1-4e7f-a96d-a84156589733";
 const LOCAL_SUPABASE_URL = process.env.SUPABASE_URL ?? "http://localhost:54321";
 const LOCAL_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
 
+const authHeaders = () => ({
+	"Content-Type": "application/json",
+	apikey: LOCAL_SERVICE_ROLE_KEY,
+	Authorization: `Bearer ${LOCAL_SERVICE_ROLE_KEY}`,
+});
+
+const findAuthUserByEmail = async (
+	email: string
+): Promise<string | undefined> => {
+	const res = await fetch(
+		`${LOCAL_SUPABASE_URL}/auth/v1/admin/users?filter=${encodeURIComponent(email)}&per_page=10`,
+		{ headers: authHeaders() }
+	);
+	if (!res.ok) return undefined;
+	const body = (await res.json()) as {
+		users?: Array<{ id: string; email: string }>;
+	};
+	return body.users?.find((u) => u.email === email)?.id;
+};
+
+const deleteAuthUser = async (userId: string): Promise<void> => {
+	await fetch(`${LOCAL_SUPABASE_URL}/auth/v1/admin/users/${userId}`, {
+		method: "DELETE",
+		headers: authHeaders(),
+	});
+};
+
 const createLocalAuthUser = async (
 	id: string,
 	email: string,
@@ -35,21 +62,43 @@ const createLocalAuthUser = async (
 ): Promise<void> => {
 	const res = await fetch(`${LOCAL_SUPABASE_URL}/auth/v1/admin/users`, {
 		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-			apikey: LOCAL_SERVICE_ROLE_KEY,
-			Authorization: `Bearer ${LOCAL_SERVICE_ROLE_KEY}`,
-		},
+		headers: authHeaders(),
 		body: JSON.stringify({ id, email, password, email_confirm: true }),
 	});
 
-	if (!res.ok) {
-		const body = (await res.json()) as { error_code?: string; msg?: string };
-		const alreadyExists =
-			body.error_code === "user_already_exists" ||
-			body.msg?.toLowerCase().includes("already");
-		if (alreadyExists) return;
+	if (res.ok) return;
+
+	const body = (await res.json()) as { error_code?: string; msg?: string };
+	const alreadyExists =
+		body.error_code === "user_already_exists" ||
+		body.msg?.toLowerCase().includes("already");
+
+	if (!alreadyExists) {
 		console.warn(`⚠️  Could not create auth user ${email}: ${body.msg}`);
+		return;
+	}
+
+	// User with this email exists — check if it has the right UUID
+	const existingId = await findAuthUserByEmail(email);
+	if (existingId === id) return; // correct UUID, nothing to do
+
+	if (existingId) {
+		// Stale user with wrong UUID — delete and recreate with correct UUID
+		console.log(
+			`🔄  Auth user ${email} exists with wrong UUID (${existingId}), replacing with ${id}…`
+		);
+		await deleteAuthUser(existingId);
+		const retry = await fetch(`${LOCAL_SUPABASE_URL}/auth/v1/admin/users`, {
+			method: "POST",
+			headers: authHeaders(),
+			body: JSON.stringify({ id, email, password, email_confirm: true }),
+		});
+		if (!retry.ok) {
+			const retryBody = (await retry.json()) as { msg?: string };
+			console.warn(
+				`⚠️  Could not recreate auth user ${email}: ${retryBody.msg}`
+			);
+		}
 	}
 };
 

--- a/src/domains/ranking/components/Leaderboard.component.tsx
+++ b/src/domains/ranking/components/Leaderboard.component.tsx
@@ -1,190 +1,60 @@
-import { useState } from "react";
-
 import { useQuery } from "@tanstack/react-query";
-import { clsx } from "clsx";
 
 import { DEFAULT_WINDOW_SIZE } from "~/domains/runs/services/pipelineEvaluator.service";
 import { calculateLevelAndCoverage } from "~/domains/runs/utils/levelCalculations";
 import { CategoryCode, getCategoryMetadata } from "~/domains/shared/categories";
+import { LeaderboardUI } from "~/ui/ranking/LeaderboardUI.ui";
 
 import { getLeaderboard } from "../api/leaderboards";
 
-type LeaderboardResponse = Awaited<ReturnType<typeof getLeaderboard>>;
-type SuccessResponse = Extract<LeaderboardResponse, { success: true }>;
-type LeaderboardEntry = SuccessResponse["data"][number];
+export const LEADERBOARD_REFRESH_INTERVAL = 3 * 60 * 1000;
+
+const getPlayerGateNumber = (pollsSeen: number): number =>
+	Math.max(1, Math.ceil(pollsSeen / DEFAULT_WINDOW_SIZE));
 
 type LeaderboardProps = {
 	categoryCode: CategoryCode;
 };
 
-const getPlayerGateNumber = (pollsSeen: number): number =>
-	Math.max(1, Math.ceil(pollsSeen / DEFAULT_WINDOW_SIZE));
-
-/**
- * Leaderboard refresh interval (3 minutes)
-
- * Rationale: Leaderboard queries are expensive (multi-table joins with aggregation).
- * A 3-minute interval reduces database load by 75% compared to 45s while still
- * providing reasonably fresh competitive rankings.
- */
-export const LEADERBOARD_REFRESH_INTERVAL = 3 * 60 * 1000;
-
-const sortOptions = [
-	{ value: "coverage", label: "Coverage" },
-	{ value: "gate-number", label: "Gate Number" },
-	{ value: "best-streak", label: "Best Streak" },
-] as const;
-
-type SortOption = (typeof sortOptions)[number]["value"];
-
-const sortByCoverage = (data: LeaderboardEntry[]): LeaderboardEntry[] => {
-	return [...data].sort((a, b) => b.totalCoverage - a.totalCoverage);
-};
-
-const sortyByBestStreak = (data: LeaderboardEntry[]): LeaderboardEntry[] => {
-	return [...data].sort((a, b) => b.bestStreak - a.bestStreak);
-};
-
-const sortByGateNumber = (data: LeaderboardEntry[]): LeaderboardEntry[] => {
-	return [...data].sort((a, b) => {
-		const gateA = getPlayerGateNumber(a.pollsSeen);
-		const gateB = getPlayerGateNumber(b.pollsSeen);
-		return gateB - gateA;
-	});
-};
-
-const sortMap: Record<
-	SortOption,
-	(data: LeaderboardEntry[]) => LeaderboardEntry[]
-> = {
-	coverage: sortByCoverage,
-	"gate-number": sortByGateNumber,
-	"best-streak": sortyByBestStreak,
-};
-
 const Leaderboard = ({ categoryCode }: LeaderboardProps) => {
-	const [sortOption, setSortOption] = useState<SortOption>("coverage");
 	const { data, isLoading, error } = useQuery({
 		queryKey: [categoryCode],
-		queryFn: () =>
-			getLeaderboard({
-				data: { categoryCode: categoryCode },
-			}),
+		queryFn: () => getLeaderboard({ data: { categoryCode } }),
 		enabled: categoryCode !== undefined,
-		staleTime: 15 * 1000, // 15 seconds
+		staleTime: 15 * 1000,
 		refetchInterval: LEADERBOARD_REFRESH_INTERVAL,
 	});
 
-	if (isLoading) return <p className="text-white">Loading leaderboard</p>;
-	if (error || !data?.success)
-		return <p className="text-red-500">Failed to load leaderboard</p>;
+	const categoryName = getCategoryMetadata(categoryCode).name;
+	const isError = !!(error || (data && !data.success));
+	const entries = data?.success
+		? data.data.map((entry) => {
+				const { displayCoverage, level } = calculateLevelAndCoverage(
+					entry.totalCoverage
+				);
+				return {
+					userId: entry.userId,
+					displayName: entry.displayName,
+					role: entry.role,
+					photoUrl: entry.photoUrl || "",
+					displayCoverage,
+					level,
+					gateNumber: getPlayerGateNumber(entry.pollsSeen),
+					totalCoverage: entry.totalCoverage,
+					bestStreak: entry.bestStreak,
+					currentStreak: entry.currentStreak,
+					correctPolls: entry.correctPolls,
+				};
+			})
+		: [];
 
 	return (
-		<section>
-			<header className="mb-6 mt-8">
-				<h2 className="text-3xl text-theme">
-					{getCategoryMetadata(categoryCode).name} category rankings
-				</h2>
-				<small>This leaderboard reflects your current run only</small>
-				<label className="flex items-center gap-2 mt-2">
-					<span>Sort by:</span>
-					<select
-						className="p-2 bg-gray-900 border border-theme"
-						value={sortOption}
-						onChange={(e) => setSortOption(e.target.value as SortOption)}
-					>
-						{sortOptions.map((option) => (
-							<option key={option.value} value={option.value}>
-								{option.label}
-							</option>
-						))}
-					</select>
-				</label>
-			</header>
-			<ol className="grid grid-cols-2 md:grid-cols-4 gap-2">
-				{sortMap[sortOption](data.data).map((entry, idx) => {
-					const { displayCoverage, level } = calculateLevelAndCoverage(
-						entry.totalCoverage
-					);
-					const isFirstPlace = idx === 0;
-
-					return (
-						<li
-							key={entry.userId}
-							className={clsx("mb-4 border p-4", {
-								"border-prismatic-first": isFirstPlace,
-								"border-theme": !isFirstPlace,
-							})}
-						>
-							<header className="flex gap-2 justify-between">
-								<span className="text-xl">#{idx + 1}</span>
-								<span>Gate {getPlayerGateNumber(entry.pollsSeen)}</span>
-							</header>
-							<section
-								className={clsx("pb-1", {
-									"border-b-prismatic": isFirstPlace,
-									"border-theme": !isFirstPlace,
-								})}
-							>
-								<h4
-									className={clsx(
-										"text-2xl text-theme leading-tight wrap-break-word",
-										{
-											"prismatic-text": isFirstPlace,
-										}
-									)}
-								>
-									{entry.displayName}
-								</h4>
-								{entry.role === "poll-editor" && (
-									<small className="text-xs text-gray-400 -mt-1 block">
-										{entry.role}
-									</small>
-								)}
-							</section>
-							<section
-								className={clsx("border-b text-sm flex gap-2 py-2", {
-									"border-b-prismatic border-b-4": isFirstPlace,
-									"border-theme": !isFirstPlace,
-								})}
-							>
-								<img
-									src={entry.photoUrl || ""}
-									alt={`photo of ${entry.displayName}`}
-									className="w-full mb-2"
-								/>
-							</section>
-							<section
-								className={clsx(
-									"border-b text-sm gap-2 py-2 flex justify-center",
-									{
-										"border-b-prismatic border-b-4": isFirstPlace,
-										"border-theme": !isFirstPlace,
-									}
-								)}
-							>
-								{level > 1 && (
-									<>
-										<span className="text-rose-500">[L{level})]</span>
-									</>
-								)}
-								<p className="text-2xl flex gap-2 items-center">
-									{displayCoverage}% <span className="text-sm">coverage</span>
-								</p>
-							</section>
-							<section className="text-sm mt-2">
-								<p className="text-lg">Run stats</p>
-								<ul className="px-4 list-disc">
-									<li>correct polls: {entry.correctPolls}</li>
-									<li>best streak: {entry.bestStreak}</li>
-									<li>current streak: {entry.currentStreak}</li>
-								</ul>
-							</section>
-						</li>
-					);
-				})}
-			</ol>
-		</section>
+		<LeaderboardUI
+			entries={entries}
+			categoryName={categoryName}
+			isLoading={isLoading}
+			isError={isError}
+		/>
 	);
 };
 

--- a/src/domains/ranking/components/SeasonInfo.component.tsx
+++ b/src/domains/ranking/components/SeasonInfo.component.tsx
@@ -1,26 +1,15 @@
-import { calculateDaysRemaining } from "../utils/seasonUtils";
+import { SeasonInfo as SeasonInfoUI } from "~/ui/ranking/SeasonInfo.ui";
 
 import type { Season } from "../models/season.model";
+import { calculateDaysRemaining } from "../utils/seasonUtils";
 
 type SeasonInfoProps = {
 	season: Season;
 };
 
-export const SeasonInfo = ({ season }: SeasonInfoProps) => {
-	const daysRemaining = calculateDaysRemaining(season.endDate);
-
-	return (
-		<div>
-			<h3 className="text-lg font-semibold text-theme mb-2">{season.name}</h3>
-			<div className="text-xs text-white">
-				{daysRemaining === 0 ? (
-					<span className="text-red-400">Ends today!</span>
-				) : daysRemaining === 1 ? (
-					<span className="text-yellow-400">Ends in 1 day</span>
-				) : (
-					<span>Ends in {daysRemaining} days</span>
-				)}
-			</div>
-		</div>
-	);
-};
+export const SeasonInfo = ({ season }: SeasonInfoProps) => (
+	<SeasonInfoUI
+		name={season.name}
+		daysRemaining={calculateDaysRemaining(season.endDate)}
+	/>
+);

--- a/src/domains/runs/components/CategoryCoverageGrid.component.tsx
+++ b/src/domains/runs/components/CategoryCoverageGrid.component.tsx
@@ -1,92 +1,29 @@
-import { clsx } from "clsx";
-
-import type { RunCategoryCoverage } from "~/domains/runs/models/runCategoryCoverage.model";
 import { CATEGORY_METADATA } from "~/domains/shared/categories";
+import type { RunCategoryCoverage } from "~/domains/runs/models/runCategoryCoverage.model";
+import { CategoryCoverageGridUI } from "~/ui/runs/CategoryCoverageGrid.ui";
 
 type CategoryCoverageGridProps = {
 	categoryCoverage: RunCategoryCoverage[];
 	currentCategoryCode?: string;
 };
 
-export const CategoryCoverageGrid: React.FC<CategoryCoverageGridProps> = ({
+export const CategoryCoverageGrid = ({
 	categoryCoverage,
 	currentCategoryCode,
-}) => {
+}: CategoryCoverageGridProps) => {
 	const highestBestStreak = Math.max(
 		...categoryCoverage.map((c) => c.bestStreak)
 	);
 
-	return (
-		<div className="space-y-2">
-			<h3 className="text-xl">Coverage score overview</h3>
+	const entries = categoryCoverage.map((coverage) => ({
+		code: coverage.categoryCode,
+		name: CATEGORY_METADATA[coverage.categoryCode].name,
+		currentCoverage: coverage.currentCoverage,
+		currentStreak: coverage.currentStreak,
+		bestStreak: coverage.bestStreak,
+		isBestStreak: coverage.bestStreak === highestBestStreak,
+		isCurrent: coverage.categoryCode === currentCategoryCode,
+	}));
 
-			<div className="grid grid-cols-4 gap-2 text-sm border-b border-theme pb-2">
-				<span>Category</span>
-				<span>Coverage</span>
-				<span>Streak</span>
-				<span>Best Streak</span>
-			</div>
-
-			<div className="space-y-1">
-				{categoryCoverage.map((coverage: RunCategoryCoverage) => {
-					const isCurrentCategory =
-						coverage.categoryCode === currentCategoryCode;
-
-					return (
-						<div
-							key={coverage.categoryCode}
-							className={clsx("grid grid-cols-4 gap-2 text-sm pl-2", {
-								"bg-theme/10 border-l-4 border-theme": isCurrentCategory,
-								"hover:bg-gray-800/50": !isCurrentCategory,
-							})}
-							aria-current={isCurrentCategory ? "true" : undefined}
-						>
-							<span
-								className={clsx("self-center", {
-									"text-theme": isCurrentCategory,
-								})}
-							>
-								{CATEGORY_METADATA[coverage.categoryCode].name}
-							</span>
-							<div className="flex flex-col gap-0">
-								<span
-									className={clsx({
-										"text-theme": isCurrentCategory,
-									})}
-								>
-									{coverage.currentCoverage.toFixed(1)}%
-								</span>
-								<meter
-									className="w-full h-2"
-									min="0"
-									max="100"
-									value={coverage.currentCoverage}
-								/>
-							</div>
-							<div className="flex gap-2">
-								<span
-									className={clsx("self-center", {
-										"text-theme": isCurrentCategory,
-									})}
-								>
-									{coverage.currentStreak}
-								</span>
-							</div>
-							<div className="flex gap-2">
-								<span
-									className={clsx("self-center", {
-										"text-theme": isCurrentCategory,
-									})}
-								>
-									{coverage.bestStreak === highestBestStreak &&
-										highestBestStreak > 0 && <>★</>}{" "}
-									{coverage.bestStreak}
-								</span>
-							</div>
-						</div>
-					);
-				})}
-			</div>
-		</div>
-	);
+	return <CategoryCoverageGridUI entries={entries} />;
 };

--- a/src/domains/runs/components/PipelineUpgradeContainer.component.tsx
+++ b/src/domains/runs/components/PipelineUpgradeContainer.component.tsx
@@ -6,8 +6,16 @@ import type {
 	PipelineEvaluation,
 	PipelineEvaluationContext,
 } from "~/domains/runs/services/pipelineEvaluator.service";
-
-import { UpgradePipelineSection } from "./UpgradePipelineSection.component";
+import {
+	formatRequirement,
+	getSlotLabel,
+} from "~/domains/runs/utils/formatPipelineRequirement";
+import { formatStorage } from "~/lib/storage";
+import {
+	PipelineUpgradeUI,
+	type UpgradeCardDisplay,
+} from "~/ui/runs/PipelineUpgrade.ui";
+import { CurrentPipeline } from "./UpgradePipelineSection.component";
 
 type PipelineUpgradeContainerProps = {
 	cards: UpgradeCard[];
@@ -18,6 +26,22 @@ type PipelineUpgradeContainerProps = {
 	evaluation?: PipelineEvaluation;
 };
 
+const toUpgradeCardDisplay = (
+	card: Extract<UpgradeCard, { kind: "upgrade-slot" | "add-slot" }>,
+	onAccept: (card: UpgradeCard) => void
+): UpgradeCardDisplay => {
+	const { slot } = card;
+	return {
+		kind: card.kind,
+		label: getSlotLabel(slot.gateTypeId),
+		difficulty: card.kind === "upgrade-slot" ? card.from : slot.difficulty,
+		upgradeTo: card.kind === "upgrade-slot" ? card.to : undefined,
+		requirement: formatRequirement(slot.requirement),
+		reward: `+${formatStorage(slot.reward)}`,
+		onSelect: () => onAccept(card),
+	};
+};
+
 export const PipelineUpgradeContainer = ({
 	cards,
 	currentSlots,
@@ -25,19 +49,33 @@ export const PipelineUpgradeContainer = ({
 	isPending,
 	evaluationContext,
 	evaluation,
-}: PipelineUpgradeContainerProps) => (
-	<div>
-		<div className="mb-4">
-			<h2 className="text-green-400 text-4xl">Pipeline check passed!</h2>
-			<span>Select a new pipeline or upgrade an existing one.</span>
-		</div>
-		<UpgradePipelineSection
-			cards={cards}
-			currentSlots={currentSlots}
-			onAccept={onAccept}
+}: PipelineUpgradeContainerProps) => {
+	const upgradeCards = cards
+		.filter(
+			(c): c is Extract<UpgradeCard, { kind: "upgrade-slot" }> =>
+				c.kind === "upgrade-slot"
+		)
+		.map((c) => toUpgradeCardDisplay(c, onAccept));
+
+	const addSlotCards = cards
+		.filter(
+			(c): c is Extract<UpgradeCard, { kind: "add-slot" }> =>
+				c.kind === "add-slot"
+		)
+		.map((c) => toUpgradeCardDisplay(c, onAccept));
+
+	return (
+		<PipelineUpgradeUI
+			pipelineSection={
+				<CurrentPipeline
+					slots={currentSlots}
+					evaluationContext={evaluationContext}
+					evaluation={evaluation}
+				/>
+			}
+			upgradeCards={upgradeCards}
+			addSlotCards={addSlotCards}
 			isPending={isPending}
-			evaluationContext={evaluationContext}
-			evaluation={evaluation}
 		/>
-	</div>
-);
+	);
+};

--- a/src/domains/runs/components/UpgradePipelineSection.component.tsx
+++ b/src/domains/runs/components/UpgradePipelineSection.component.tsx
@@ -1,146 +1,22 @@
-import type {
-	GateDifficulty,
-	PipelineSlot,
-	UpgradeCard,
-} from "~/domains/runs/models/pipeline.model";
+import type { PipelineSlot } from "~/domains/runs/models/pipeline.model";
 import type {
 	PipelineEvaluation,
 	PipelineEvaluationContext,
 	SlotEvaluationStatus,
 } from "~/domains/runs/services/pipelineEvaluator.service";
 import { formatCurrentStat } from "~/domains/runs/utils/formatCurrentStat";
-import { DIFFICULTY_CLASSES } from "~/domains/runs/utils/difficultyStyles";
 import {
 	formatRequirement,
 	getSlotLabel,
 } from "~/domains/runs/utils/formatPipelineRequirement";
 import { formatStorage } from "~/lib/storage";
-
-const RewardBadge = ({ reward }: { reward: number }) => (
-	<span className="text-emerald-400 text-xs whitespace-nowrap">
-		+{formatStorage(reward)} storage
-	</span>
-);
-
-type UpgradePipelineSectionProps = {
-	cards: UpgradeCard[];
-	currentSlots: PipelineSlot[];
-	onAccept: (card: UpgradeCard) => void;
-	isPending?: boolean;
-	evaluationContext?: PipelineEvaluationContext;
-	evaluation?: PipelineEvaluation;
-};
-
-const SelectButton = ({
-	onClick,
-	disabled,
-}: {
-	onClick: () => void;
-	disabled: boolean;
-}) => (
-	<button
-		onClick={onClick}
-		disabled={disabled}
-		className="border border-white px-4 py-2 text-lg text-white hover:bg-white hover:text-black transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-	>
-		Select
-	</button>
-);
-
-const CardEntry = ({
-	card,
-	onAccept,
-	isPending,
-}: {
-	card: UpgradeCard;
-	onAccept: (card: UpgradeCard) => void;
-	isPending: boolean;
-}) => {
-	const { slot } = card;
-	const isUpgrade = card.kind === "upgrade-slot";
-
-	return (
-		<div className="border border-white p-4 space-y-1">
-			<div className="flex items-center gap-2 mb-2">
-				<span className="text-zinc-300">{isUpgrade ? "↑" : "+"}</span>
-				<span>{getSlotLabel(slot.gateTypeId)} · </span>
-				<DifficultyLabel difficulty={isUpgrade ? card.from : slot.difficulty} />
-				{isUpgrade && <DifficultyLabel text={"→"} difficulty={card.to} />}
-			</div>
-			<p className="text-zinc-300 text-sm pl-4">
-				Requirement:{" "}
-				<span className="text-gray-200">
-					{formatRequirement(slot.requirement)}
-				</span>
-			</p>
-			<p className="text-zinc-300 text-sm pl-4">
-				Reward on pass: <RewardBadge reward={slot.reward} />
-			</p>
-
-			<div className="pl-4 pt-2">
-				<SelectButton onClick={() => onAccept(card)} disabled={isPending} />
-			</div>
-		</div>
-	);
-};
-
-const SectionHeader = ({
-	title,
-	subtitle,
-}: {
-	title: string;
-	subtitle: string;
-}) => (
-	<div className="border border-white px-4 py-3">
-		<h1 className="text-2xl">{title}</h1>
-		<p className="text-zinc-300 text-xs mt-0.5">{subtitle}</p>
-	</div>
-);
-
-const DifficultyLabel = ({
-	difficulty,
-	text,
-}: {
-	difficulty: GateDifficulty;
-	text?: string;
-}) => (
-	<span className={DIFFICULTY_CLASSES[difficulty]}>
-		<span className="text-white">{text}</span> {difficulty}
-	</span>
-);
+import {
+	CurrentPipelineUI,
+	type CurrentPipelineSlot,
+} from "~/ui/runs/PipelineUpgrade.ui";
+import type { SlotStatus } from "~/ui/runs/pipelineStyles";
 
 type StatusWithInProgress = SlotEvaluationStatus | "in-progress";
-
-const STATUS_ICON: Record<StatusWithInProgress, React.ReactNode> = {
-	"in-progress": (
-		<span className="inline-block w-3 h-3 rounded-full bg-yellow-400 animate-pulse" />
-	),
-	passed: <span className="text-green-400">✓</span>,
-	failed: <span className="text-red-400">✗</span>,
-	skipped: <span className="inline-block w-3 h-3 rounded-full bg-zinc-300" />,
-};
-
-const STATUS_GROUP_LABEL: Record<StatusWithInProgress, string> = {
-	"in-progress": "in progress",
-	passed: "successful",
-	failed: "failing",
-	skipped: "skipped",
-};
-
-const CheckGroupHeader = ({
-	status,
-	count,
-}: {
-	status: StatusWithInProgress;
-	count: number;
-}) => (
-	<div className="px-4 py-2 border-b border-white bg-white/5 flex items-center gap-2 text-sm text-gray-400">
-		{STATUS_ICON[status]}
-		<span>
-			{count} {STATUS_GROUP_LABEL[status]} {count === 1 ? "check" : "checks"}
-		</span>
-	</div>
-);
 
 const getLiveStatus = (
 	slot: PipelineSlot,
@@ -154,6 +30,29 @@ const getLiveStatus = (
 	return "in-progress";
 };
 
+export const toCurrentPipelineSlots = (
+	slots: PipelineSlot[],
+	evaluationContext?: PipelineEvaluationContext,
+	evaluation?: PipelineEvaluation
+): CurrentPipelineSlot[] =>
+	slots.map((slot, i) => {
+		const status = evaluation
+			? ((evaluation.slotEvaluations[i]?.status ?? "in-progress") as SlotStatus)
+			: getLiveStatus(slot, evaluationContext);
+		return {
+			id: `${slot.gateTypeId}-${i}`,
+			status,
+			label: getSlotLabel(slot.gateTypeId),
+			difficulty: slot.difficulty,
+			requirement: formatRequirement(slot.requirement),
+			reward: `+${formatStorage(slot.reward)}`,
+			currentStat:
+				status === "in-progress" && evaluationContext
+					? formatCurrentStat(slot.requirement, evaluationContext)
+					: undefined,
+		};
+	});
+
 export const CurrentPipeline = ({
 	slots,
 	evaluationContext,
@@ -163,168 +62,31 @@ export const CurrentPipeline = ({
 	evaluationContext?: PipelineEvaluationContext;
 	evaluation?: PipelineEvaluation;
 }) => {
-	const slotsWithStatus = slots.map((slot, i) => ({
-		slot,
-		status: evaluation
-			? ((evaluation.slotEvaluations[i]?.status ??
-					"in-progress") as StatusWithInProgress)
-			: getLiveStatus(slot, evaluationContext),
-	}));
-
-	const groups = (
-		["in-progress", "passed", "failed", "skipped"] as StatusWithInProgress[]
-	)
-		.map((status) => ({
-			status,
-			entries: slotsWithStatus.filter((s) => s.status === status),
-		}))
-		.filter((g) => g.entries.length > 0);
-
 	const totalPotentialReward = slots.reduce((sum, s) => sum + s.reward, 0);
 
 	return (
-		<div className="border border-white">
-			<div className="border-b border-white px-4 py-3">
-				<div className="flex items-baseline justify-between">
-					<p className="text-2xl">CI Pipelines</p>
-					{evaluationContext && (
-						<span className="text-xl">
-							Gate #{evaluationContext.currentGate}
-						</span>
-					)}
-				</div>
-				<p className="text-zinc-300 text-sm mt-0.5">
-					{evaluationContext && (
-						<>
-							<span>
-								{evaluationContext.pollsInWindow -
-									evaluationContext.pollsAnsweredInWindow}{" "}
-								polls left until next gate check
-							</span>
-							{" · "}
-						</>
-					)}
-					{slots.length} active {slots.length === 1 ? "check" : "checks"} · all
-					<span className="text-yellow-400"> pending</span> checks must pass
-				</p>
-				{!evaluation && totalPotentialReward > 0 && (
-					<p className="text-sm mt-1">
-						Total reward if all pass:{" "}
-						<RewardBadge reward={totalPotentialReward} />
-					</p>
-				)}
-			</div>
-
-			{evaluation?.passed && evaluation.totalReward > 0 && (
-				<div className="bg-emerald-950/40 border-b border-emerald-500/50 px-4 py-3">
-					<p className="text-emerald-300 text-lg">
-						✓ Pipeline cleared — +{formatStorage(evaluation.totalReward)}{" "}
-						storage added to your limit
-					</p>
-				</div>
-			)}
-
-			{groups.map(({ status, entries }) => (
-				<div key={status}>
-					{evaluation && (
-						<CheckGroupHeader status={status} count={entries.length} />
-					)}
-					{entries.map(({ slot }, i) => (
-						<section
-							key={`${slot.gateTypeId}-${i}`}
-							className="flex items-start gap-3 border-b border-white last:border-b-0 px-4 py-3"
-						>
-							<span className="mt-0.5 shrink-0">{STATUS_ICON[status]}</span>
-							<div>
-								<p>
-									<span className={DIFFICULTY_CLASSES[slot.difficulty]}>
-										{getSlotLabel(slot.gateTypeId)}
-									</span>
-								</p>
-								<DifficultyLabel text="Risk:" difficulty={slot.difficulty} />
-								{" · "}
-								Requirement: {formatRequirement(slot.requirement)}
-								{" · "}
-								Reward: <RewardBadge reward={slot.reward} />
-								{evaluationContext && (
-									<p>
-										Current:{" "}
-										<span className="text-gray-300">
-											{formatCurrentStat(slot.requirement, evaluationContext)}
-										</span>
-									</p>
-								)}
-							</div>
-						</section>
-					))}
-				</div>
-			))}
-		</div>
-	);
-};
-
-export const UpgradePipelineSection = ({
-	cards,
-	currentSlots,
-	onAccept,
-	isPending = false,
-	evaluationContext,
-	evaluation,
-}: UpgradePipelineSectionProps) => {
-	const upgradeCards = cards.filter(
-		(c): c is Extract<UpgradeCard, { kind: "upgrade-slot" }> =>
-			c.kind === "upgrade-slot"
-	);
-	const addSlotCards = cards.filter(
-		(c): c is Extract<UpgradeCard, { kind: "add-slot" }> =>
-			c.kind === "add-slot"
-	);
-
-	return (
-		<div className="space-y-6">
-			<CurrentPipeline
-				slots={currentSlots}
-				evaluationContext={evaluationContext}
-				evaluation={evaluation}
-			/>
-
-			<section className="flex flex-col gap-6">
-				{upgradeCards.length > 0 && (
-					<div className="space-y-4">
-						<SectionHeader
-							title="Modify Existing Slots"
-							subtitle="Increase difficulty, higher reward, higher risk"
-						/>
-						{upgradeCards.map((card, i) => (
-							<CardEntry
-								key={i}
-								card={card}
-								onAccept={onAccept}
-								isPending={isPending}
-							/>
-						))}
-					</div>
-				)}
-
-				{addSlotCards.length > 0 && (
-					<div className="space-y-4">
-						<SectionHeader
-							title="Add New Slot"
-							subtitle="More constraints, harder to pass all"
-						/>
-						<div className="grid grid-cols-1 gap-4">
-							{addSlotCards.map((card, i) => (
-								<CardEntry
-									key={i}
-									card={card}
-									onAccept={onAccept}
-									isPending={isPending}
-								/>
-							))}
-						</div>
-					</div>
-				)}
-			</section>
-		</div>
+		<CurrentPipelineUI
+			gateNumber={evaluationContext?.currentGate}
+			pollsLeft={
+				evaluationContext
+					? evaluationContext.pollsInWindow -
+						evaluationContext.pollsAnsweredInWindow
+					: undefined
+			}
+			totalPotentialReward={
+				!evaluation && totalPotentialReward > 0
+					? `+${formatStorage(totalPotentialReward)}`
+					: undefined
+			}
+			evaluation={
+				evaluation
+					? {
+							passed: evaluation.passed,
+							totalReward: `+${formatStorage(evaluation.totalReward)}`,
+						}
+					: undefined
+			}
+			slots={toCurrentPipelineSlots(slots, evaluationContext, evaluation)}
+		/>
 	);
 };

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,6 +1,8 @@
 @import "tailwindcss";
 @import "highlight.js/styles/github-dark.css";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 @layer base {
 	html {
 		color-scheme: light dark;

--- a/src/ui/CatchBoundaryUI.stories.tsx
+++ b/src/ui/CatchBoundaryUI.stories.tsx
@@ -3,7 +3,7 @@ import { CatchBoundaryUI } from "./CatchBoundaryUI.component";
 
 const meta: Meta<typeof CatchBoundaryUI> = {
 	component: CatchBoundaryUI,
-	title: "UI/CatchBoundaryUI",
+	title: "Pages/Catch Boundary",
 };
 export default meta;
 

--- a/src/ui/ConfirmDialog.stories.tsx
+++ b/src/ui/ConfirmDialog.stories.tsx
@@ -3,7 +3,7 @@ import { ConfirmDialog } from "./ConfirmDialog.component";
 
 const meta: Meta<typeof ConfirmDialog> = {
 	component: ConfirmDialog,
-	title: "UI/ConfirmDialog",
+	title: "Molecules/Confirm Dialog",
 };
 export default meta;
 

--- a/src/ui/ContentSection.stories.tsx
+++ b/src/ui/ContentSection.stories.tsx
@@ -3,7 +3,7 @@ import { ContentSection } from "./ContentSection.component";
 
 const meta: Meta<typeof ContentSection> = {
 	component: ContentSection,
-	title: "UI/ContentSection",
+	title: "Atoms/Content Section",
 };
 export default meta;
 

--- a/src/ui/DevPollNavigatorUI.stories.tsx
+++ b/src/ui/DevPollNavigatorUI.stories.tsx
@@ -3,7 +3,7 @@ import { DevPollNavigatorUI } from "./DevPollNavigatorUI.component";
 
 const meta: Meta<typeof DevPollNavigatorUI> = {
 	component: DevPollNavigatorUI,
-	title: "UI/DevPollNavigatorUI",
+	title: "Molecules/Dev Poll Navigator",
 };
 export default meta;
 

--- a/src/ui/Dropdown.stories.tsx
+++ b/src/ui/Dropdown.stories.tsx
@@ -3,7 +3,7 @@ import { Dropdown, DropdownItem, DropdownDivider } from "./Dropdown.component";
 
 const meta: Meta<typeof Dropdown> = {
 	component: Dropdown,
-	title: "UI/Dropdown",
+	title: "Molecules/Dropdown",
 };
 export default meta;
 

--- a/src/ui/ErrorComponent.stories.tsx
+++ b/src/ui/ErrorComponent.stories.tsx
@@ -3,7 +3,7 @@ import { ErrorComponent } from "./ErrorComponent.component";
 
 const meta: Meta<typeof ErrorComponent> = {
 	component: ErrorComponent,
-	title: "UI/ErrorComponent",
+	title: "Pages/Error",
 };
 export default meta;
 

--- a/src/ui/FooterUI.stories.tsx
+++ b/src/ui/FooterUI.stories.tsx
@@ -3,7 +3,7 @@ import { FooterUI } from "./FooterUI.component";
 
 const meta: Meta<typeof FooterUI> = {
 	component: FooterUI,
-	title: "UI/FooterUI",
+	title: "Organisms/Footer",
 };
 export default meta;
 

--- a/src/ui/GameLoopExplainer.stories.tsx
+++ b/src/ui/GameLoopExplainer.stories.tsx
@@ -3,7 +3,7 @@ import { GameLoopExplainer } from "./GameLoopExplainer.component";
 
 const meta: Meta<typeof GameLoopExplainer> = {
 	component: GameLoopExplainer,
-	title: "UI/GameLoopExplainer",
+	title: "Organisms/Game Loop Explainer",
 };
 export default meta;
 

--- a/src/ui/LoadingSkeleton.stories.tsx
+++ b/src/ui/LoadingSkeleton.stories.tsx
@@ -3,7 +3,7 @@ import { LoadingSkeleton } from "./LoadingSkeleton.component";
 
 const meta: Meta<typeof LoadingSkeleton> = {
 	component: LoadingSkeleton,
-	title: "UI/LoadingSkeleton",
+	title: "Atoms/Loading Skeleton",
 };
 export default meta;
 

--- a/src/ui/NotFoundUI.stories.tsx
+++ b/src/ui/NotFoundUI.stories.tsx
@@ -3,7 +3,7 @@ import { NotFoundUI } from "./NotFoundUI.component";
 
 const meta: Meta<typeof NotFoundUI> = {
 	component: NotFoundUI,
-	title: "UI/NotFoundUI",
+	title: "Pages/Not Found",
 };
 export default meta;
 

--- a/src/ui/PageLayoutUI.stories.tsx
+++ b/src/ui/PageLayoutUI.stories.tsx
@@ -3,7 +3,7 @@ import { PageLayoutUI } from "./PageLayoutUI.component";
 
 const meta: Meta<typeof PageLayoutUI> = {
 	component: PageLayoutUI,
-	title: "UI/PageLayoutUI",
+	title: "Templates/Page Layout",
 };
 export default meta;
 

--- a/src/ui/Popover.stories.tsx
+++ b/src/ui/Popover.stories.tsx
@@ -3,7 +3,7 @@ import { Popover } from "./Popover.component";
 
 const meta: Meta<typeof Popover> = {
 	component: Popover,
-	title: "UI/Popover",
+	title: "Molecules/Popover",
 };
 export default meta;
 

--- a/src/ui/PrimaryButton.stories.tsx
+++ b/src/ui/PrimaryButton.stories.tsx
@@ -3,7 +3,7 @@ import { PrimaryButton } from "./PrimaryButton.component";
 
 const meta: Meta<typeof PrimaryButton> = {
 	component: PrimaryButton,
-	title: "UI/PrimaryButton",
+	title: "Atoms/Buttons/Primary",
 };
 export default meta;
 

--- a/src/ui/SecondaryButton.stories.tsx
+++ b/src/ui/SecondaryButton.stories.tsx
@@ -3,7 +3,7 @@ import { SecondaryButton } from "./SecondaryButton.component";
 
 const meta: Meta<typeof SecondaryButton> = {
 	component: SecondaryButton,
-	title: "UI/SecondaryButton",
+	title: "Atoms/Buttons/Secondary",
 };
 export default meta;
 

--- a/src/ui/TextButton.stories.tsx
+++ b/src/ui/TextButton.stories.tsx
@@ -3,7 +3,7 @@ import { TextButton } from "./TextButton.component";
 
 const meta: Meta<typeof TextButton> = {
 	component: TextButton,
-	title: "UI/TextButton",
+	title: "Atoms/Buttons/Text",
 };
 export default meta;
 

--- a/src/ui/economy/ConfigCard.ui.stories.tsx
+++ b/src/ui/economy/ConfigCard.ui.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ConfigCard } from "./ConfigCard.ui";
+
+const meta: Meta<typeof ConfigCard> = {
+	component: ConfigCard,
+	title: "Economy/Molecules/Config Card",
+};
+export default meta;
+
+type Story = StoryObj<typeof ConfigCard>;
+
+export const Common: Story = {
+	args: {
+		name: "Cache Warmer",
+		cost: "64 KB",
+		refund: "32 KB",
+		rarity: "common",
+		description: "Preloads the most frequently accessed poll data into memory.",
+	},
+};
+
+export const Uncommon: Story = {
+	args: {
+		name: "Null Coalescer",
+		cost: "128 KB",
+		refund: "64 KB",
+		rarity: "uncommon",
+		description: "Converts undefined poll answers into safe defaults.",
+	},
+};
+
+export const Rare: Story = {
+	args: {
+		name: "Banjo's Backpack",
+		cost: "256 KB",
+		refund: "128 KB",
+		rarity: "rare",
+		description: "Grants +0.5% coverage bonus per correct poll answered.",
+	},
+};
+
+export const Legendary: Story = {
+	args: {
+		name: "Kazooie's Wing Whack",
+		cost: "512 KB",
+		refund: "256 KB",
+		rarity: "legendary",
+		description:
+			"Doubles coverage gain for your next gate window. Legendary power.",
+	},
+};
+
+export const SmallSize: Story = {
+	args: {
+		name: "Cache Warmer",
+		cost: "64 KB",
+		refund: "32 KB",
+		rarity: "common",
+		description: "Preloads poll data.",
+		size: "small",
+	},
+};
+
+export const Disabled: Story = {
+	args: {
+		name: "Null Coalescer",
+		cost: "128 KB",
+		refund: "64 KB",
+		rarity: "uncommon",
+		description: "Not enough storage to install.",
+		disabled: true,
+	},
+};

--- a/src/ui/economy/ConfigCard.ui.tsx
+++ b/src/ui/economy/ConfigCard.ui.tsx
@@ -1,0 +1,81 @@
+import { clsx } from "clsx";
+
+export type Rarity = "common" | "uncommon" | "rare" | "legendary";
+
+export const RARITY_COLORS: Record<
+	Rarity,
+	{ border: string; text: string; bg: string }
+> = {
+	common: {
+		border: "border-cerulean",
+		text: "text-cerulean",
+		bg: "bg-cerulean/15",
+	},
+	uncommon: {
+		border: "border-celadon",
+		text: "text-celadon",
+		bg: "bg-celadon/15",
+	},
+	rare: {
+		border: "border-cinnabar",
+		text: "text-cinnabar",
+		bg: "bg-cinnabar/15",
+	},
+	legendary: {
+		border: "border-indigo",
+		text: "text-indigo",
+		bg: "bg-indigo/15",
+	},
+};
+
+export type ConfigCardProps = {
+	name: string;
+	cost: string;
+	refund: string;
+	rarity: Rarity;
+	description: string;
+	size?: "small" | "large";
+	disabled?: boolean;
+};
+
+export const ConfigCard = ({
+	name,
+	cost,
+	refund,
+	rarity,
+	description,
+	size = "large",
+	disabled = false,
+}: ConfigCardProps) => {
+	const colors = RARITY_COLORS[rarity];
+
+	if (size === "small") {
+		return (
+			<article
+				className={clsx("border p-2 min-w-40", colors.border, colors.bg)}
+			>
+				<span className={`text-xs ${colors.text}`}>({rarity})</span>
+				<h3 className={clsx("text-md", colors.text)}>{name}</h3>
+			</article>
+		);
+	}
+
+	return (
+		<article
+			className={clsx(
+				"border p-4 w-52 min-h-52",
+				colors.border,
+				colors.bg,
+				disabled && "opacity-50 cursor-not-allowed"
+			)}
+		>
+			<h3 className={clsx("text-2xl", colors.text)}>{name}</h3>
+			<p>Cost: {cost}</p>
+			<p>Refund: {refund}</p>
+			<p>
+				Rarity: <span className={colors.text}>{rarity}</span>
+			</p>
+			<p className="border-t border-t-white mt-2 pt-2">{description}</p>
+		</article>
+	);
+};

--- a/src/ui/economy/ShopCard.ui.stories.tsx
+++ b/src/ui/economy/ShopCard.ui.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ShopCard } from "./ShopCard.ui";
+
+const meta: Meta<typeof ShopCard> = {
+	component: ShopCard,
+	title: "Economy/Molecules/Shop Card",
+	decorators: [
+		(Story) => (
+			<div className="flex gap-4 flex-wrap">
+				<Story />
+			</div>
+		),
+	],
+};
+export default meta;
+
+type Story = StoryObj<typeof ShopCard>;
+
+const baseConfig = {
+	name: "Cache Warmer",
+	cost: "64 KB",
+	refund: "32 KB",
+	rarity: "common" as const,
+	description: "Preloads the most frequently accessed poll data into memory.",
+	onInstall: () => {},
+};
+
+export const Available: Story = {
+	args: { ...baseConfig, canAfford: true, isShopOpen: true },
+};
+
+export const Installed: Story = {
+	args: { ...baseConfig, isInstalled: true },
+};
+
+export const CantAfford: Story = {
+	args: { ...baseConfig, canAfford: false, isShopOpen: true },
+};
+
+export const ShopClosed: Story = {
+	args: { ...baseConfig, canAfford: true, isShopOpen: false },
+};
+
+export const RarityShowcase: Story = {
+	render: () => (
+		<div className="flex gap-4 flex-wrap">
+			{(["common", "uncommon", "rare", "legendary"] as const).map((rarity) => (
+				<ShopCard
+					key={rarity}
+					name="Mumbo's Magic"
+					cost="128 KB"
+					refund="64 KB"
+					rarity={rarity}
+					description={`A ${rarity} config with special powers.`}
+					canAfford={true}
+					isShopOpen={true}
+					onInstall={() => {}}
+				/>
+			))}
+		</div>
+	),
+};

--- a/src/ui/economy/ShopCard.ui.tsx
+++ b/src/ui/economy/ShopCard.ui.tsx
@@ -1,0 +1,69 @@
+import { clsx } from "clsx";
+
+import { ConfigCard, RARITY_COLORS, type Rarity } from "./ConfigCard.ui";
+
+export type ShopCardProps = {
+	name: string;
+	cost: string;
+	refund: string;
+	rarity: Rarity;
+	description: string;
+	isInstalled?: boolean;
+	canAfford?: boolean;
+	isShopOpen?: boolean;
+	onInstall: () => void;
+};
+
+export const ShopCard = ({
+	name,
+	cost,
+	refund,
+	rarity,
+	description,
+	isInstalled = false,
+	canAfford = true,
+	isShopOpen = true,
+	onInstall,
+}: ShopCardProps) => {
+	const colors = RARITY_COLORS[rarity];
+	const isInteractive = !isInstalled && canAfford && isShopOpen;
+
+	const buttonLabel = isInstalled
+		? "✓ Installed"
+		: !canAfford
+			? "Not enough storage"
+			: !isShopOpen
+				? "Shop closed"
+				: "Install";
+
+	return (
+		<div
+			className={clsx(
+				"flex flex-col gap-2 transition-transform",
+				isInteractive && "hover:scale-105 cursor-pointer"
+			)}
+		>
+			<ConfigCard
+				name={name}
+				cost={cost}
+				refund={refund}
+				rarity={rarity}
+				description={description}
+				disabled={!isInteractive}
+				size="large"
+			/>
+			<button
+				onClick={isInteractive ? onInstall : undefined}
+				disabled={!isInteractive}
+				className={clsx("border p-2 w-full", {
+					"border-green-600 text-green-400 opacity-70 cursor-not-allowed":
+						isInstalled,
+					"opacity-50 cursor-not-allowed": !isInstalled && !isInteractive,
+					[`${colors.border} ${colors.text} cursor-pointer`]: isInteractive,
+				})}
+			>
+				{buttonLabel}
+			</button>
+		</div>
+	);
+};

--- a/src/ui/economy/StorageBreakdown.ui.stories.tsx
+++ b/src/ui/economy/StorageBreakdown.ui.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { StorageBreakdown } from "./StorageBreakdown.ui";
+
+const meta: Meta<typeof StorageBreakdown> = {
+	component: StorageBreakdown,
+	title: "Economy/Molecules/Storage Breakdown",
+	decorators: [
+		(Story) => (
+			<div className="max-w-xs">
+				<Story />
+			</div>
+		),
+	],
+};
+export default meta;
+
+type Story = StoryObj<typeof StorageBreakdown>;
+
+const MB = 1024 * 1024;
+const KB = 1024;
+
+export const Typical: Story = {
+	args: {
+		storageLimit: 2 * MB,
+		storageUsed: 896 * KB,
+		storageAvailable: MB + 128 * KB,
+		configsStorage: 768 * KB,
+		rerollsStorage: 128 * KB,
+		deinstallPenalty: 0,
+		injectedArchive: 0,
+		recentGain: null,
+	},
+};
+
+export const WithRecentGain: Story = {
+	args: {
+		storageLimit: 2 * MB,
+		storageUsed: 512 * KB,
+		storageAvailable: 1536 * KB,
+		configsStorage: 512 * KB,
+		rerollsStorage: 0,
+		deinstallPenalty: 0,
+		injectedArchive: 0,
+		recentGain: 512 * KB,
+	},
+};
+
+export const WithInjectedArchive: Story = {
+	args: {
+		storageLimit: 2.5 * MB,
+		storageUsed: 640 * KB,
+		storageAvailable: 1920 * KB,
+		configsStorage: 512 * KB,
+		rerollsStorage: 128 * KB,
+		deinstallPenalty: 0,
+		injectedArchive: 512 * KB,
+		recentGain: null,
+	},
+};
+
+export const NearlyFull: Story = {
+	args: {
+		storageLimit: MB,
+		storageUsed: 960 * KB,
+		storageAvailable: 64 * KB,
+		configsStorage: 768 * KB,
+		rerollsStorage: 128 * KB,
+		deinstallPenalty: 64 * KB,
+		injectedArchive: 0,
+		recentGain: null,
+	},
+};
+
+export const Empty: Story = {
+	args: {
+		storageLimit: MB,
+		storageUsed: 0,
+		storageAvailable: MB,
+		configsStorage: 0,
+		rerollsStorage: 0,
+		deinstallPenalty: 0,
+		injectedArchive: 0,
+		recentGain: null,
+	},
+};

--- a/src/ui/economy/StorageBreakdown.ui.tsx
+++ b/src/ui/economy/StorageBreakdown.ui.tsx
@@ -1,0 +1,86 @@
+import { formatStorage, formatStorageDetailed } from "~/lib/storage";
+
+export type StorageBreakdownProps = {
+	storageUsed: number;
+	storageLimit: number;
+	storageAvailable: number;
+	configsStorage: number;
+	rerollsStorage: number;
+	deinstallPenalty: number;
+	injectedArchive?: number;
+	recentGain?: number | null;
+};
+
+export const StorageBreakdown = ({
+	storageUsed,
+	storageLimit,
+	storageAvailable,
+	configsStorage,
+	rerollsStorage,
+	deinstallPenalty,
+	injectedArchive = 0,
+	recentGain = null,
+}: StorageBreakdownProps) => {
+	const usagePercentage =
+		storageLimit > 0 ? (storageUsed / storageLimit) * 100 : 0;
+
+	return (
+		<div className="space-y-4">
+			<div className="flex items-baseline justify-between gap-2">
+				<h3 className="text-xl text-cyan-400">Storage</h3>
+				{recentGain !== null && recentGain > 0 && (
+					<span className="text-emerald-300 text-sm border border-emerald-400 px-2 py-0.5 animate-pulse">
+						+{formatStorage(recentGain)} just earned
+					</span>
+				)}
+			</div>
+
+			<div className="space-y-1">
+				<div className="flex items-center gap-4">
+					<div className="flex-1 h-4 border border-white/50 relative">
+						<div
+							className="h-full bg-white/80 transition-all duration-500"
+							style={{ width: `${Math.min(usagePercentage, 100)}%` }}
+						/>
+					</div>
+					<span className="text-sm whitespace-nowrap">
+						{formatStorage(storageUsed)} /{" "}
+						<span className={recentGain !== null ? "text-emerald-300" : ""}>
+							{formatStorageDetailed(storageLimit)}
+						</span>
+					</span>
+				</div>
+
+				{storageAvailable > 0 && (
+					<p className="text-green-500 text-sm">
+						{formatStorageDetailed(storageAvailable)} available
+					</p>
+				)}
+			</div>
+
+			<div className="space-y-2">
+				<h4 className="text-sm text-gray-400">Breakdown</h4>
+				<dl className="space-y-1 text-sm">
+					{injectedArchive > 0 && (
+						<div className="flex justify-between text-amber-300">
+							<dt>Injected from archive</dt>
+							<dd>+{formatStorage(injectedArchive)}</dd>
+						</div>
+					)}
+					<div className="flex justify-between">
+						<dt>Active configs</dt>
+						<dd>{formatStorage(configsStorage)}</dd>
+					</div>
+					<div className="flex justify-between">
+						<dt>Rebuilds</dt>
+						<dd>{formatStorage(rerollsStorage)}</dd>
+					</div>
+					<div className="flex justify-between">
+						<dt>Junk</dt>
+						<dd>{formatStorage(deinstallPenalty)}</dd>
+					</div>
+				</dl>
+			</div>
+		</div>
+	);
+};

--- a/src/ui/ranking/LeaderboardUI.ui.stories.tsx
+++ b/src/ui/ranking/LeaderboardUI.ui.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { LeaderboardUI } from "./LeaderboardUI.ui";
+
+const meta: Meta<typeof LeaderboardUI> = {
+	component: LeaderboardUI,
+	title: "Ranking/Organisms/Leaderboard",
+};
+export default meta;
+
+type Story = StoryObj<typeof LeaderboardUI>;
+
+const sampleEntries = [
+	{
+		userId: "1",
+		displayName: "Banjo",
+		photoUrl: "",
+		displayCoverage: 87,
+		level: 3,
+		gateNumber: 5,
+		totalCoverage: 18700,
+		bestStreak: 12,
+		currentStreak: 4,
+		correctPolls: 42,
+	},
+	{
+		userId: "2",
+		displayName: "Kazooie",
+		role: "poll-editor" as const,
+		photoUrl: "",
+		displayCoverage: 72,
+		level: 2,
+		gateNumber: 4,
+		totalCoverage: 14400,
+		bestStreak: 8,
+		currentStreak: 8,
+		correctPolls: 31,
+	},
+	{
+		userId: "3",
+		displayName: "Mumbo Jumbo",
+		photoUrl: "",
+		displayCoverage: 55,
+		level: 1,
+		gateNumber: 3,
+		totalCoverage: 5500,
+		bestStreak: 5,
+		currentStreak: 2,
+		correctPolls: 18,
+	},
+];
+
+export const WithEntries: Story = {
+	args: {
+		entries: sampleEntries,
+		categoryName: "JavaScript",
+		isLoading: false,
+		isError: false,
+	},
+};
+
+export const Loading: Story = {
+	args: {
+		entries: [],
+		categoryName: "JavaScript",
+		isLoading: true,
+		isError: false,
+	},
+};
+
+export const Error: Story = {
+	args: {
+		entries: [],
+		categoryName: "JavaScript",
+		isLoading: false,
+		isError: true,
+	},
+};
+
+export const Empty: Story = {
+	args: {
+		entries: [],
+		categoryName: "TypeScript",
+		isLoading: false,
+		isError: false,
+	},
+};

--- a/src/ui/ranking/LeaderboardUI.ui.tsx
+++ b/src/ui/ranking/LeaderboardUI.ui.tsx
@@ -1,0 +1,158 @@
+import { useState } from "react";
+
+import { clsx } from "clsx";
+
+export type LeaderboardPlayerDisplay = {
+	userId: string;
+	displayName: string;
+	role?: string;
+	photoUrl: string;
+	displayCoverage: number;
+	level: number;
+	gateNumber: number;
+	totalCoverage: number;
+	bestStreak: number;
+	currentStreak: number | null;
+	correctPolls: number;
+};
+
+const sortOptions = [
+	{ value: "coverage", label: "Coverage" },
+	{ value: "gate-number", label: "Gate Number" },
+	{ value: "best-streak", label: "Best Streak" },
+] as const;
+
+type SortOption = (typeof sortOptions)[number]["value"];
+
+const sortFns: Record<
+	SortOption,
+	(a: LeaderboardPlayerDisplay, b: LeaderboardPlayerDisplay) => number
+> = {
+	coverage: (a, b) => b.totalCoverage - a.totalCoverage,
+	"gate-number": (a, b) => b.gateNumber - a.gateNumber,
+	"best-streak": (a, b) => b.bestStreak - a.bestStreak,
+};
+
+type LeaderboardUIProps = {
+	entries: LeaderboardPlayerDisplay[];
+	categoryName: string;
+	isLoading: boolean;
+	isError: boolean;
+};
+
+export const LeaderboardUI = ({
+	entries,
+	categoryName,
+	isLoading,
+	isError,
+}: LeaderboardUIProps) => {
+	const [sortOption, setSortOption] = useState<SortOption>("coverage");
+
+	if (isLoading) return <p className="text-white">Loading leaderboard</p>;
+	if (isError)
+		return <p className="text-red-500">Failed to load leaderboard</p>;
+
+	const sorted = [...entries].sort(sortFns[sortOption]);
+
+	return (
+		<section>
+			<header className="mb-6 mt-8">
+				<h2 className="text-3xl text-theme">
+					{categoryName} category rankings
+				</h2>
+				<small>This leaderboard reflects your current run only</small>
+				<label className="flex items-center gap-2 mt-2">
+					<span>Sort by:</span>
+					<select
+						className="p-2 bg-gray-900 border border-theme"
+						value={sortOption}
+						onChange={(e) => setSortOption(e.target.value as SortOption)}
+					>
+						{sortOptions.map((option) => (
+							<option key={option.value} value={option.value}>
+								{option.label}
+							</option>
+						))}
+					</select>
+				</label>
+			</header>
+			<ol className="grid grid-cols-2 md:grid-cols-4 gap-2">
+				{sorted.map((entry, idx) => {
+					const isFirstPlace = idx === 0;
+
+					return (
+						<li
+							key={entry.userId}
+							className={clsx("mb-4 border p-4", {
+								"border-prismatic-first": isFirstPlace,
+								"border-theme": !isFirstPlace,
+							})}
+						>
+							<header className="flex gap-2 justify-between">
+								<span className="text-xl">#{idx + 1}</span>
+								<span>Gate {entry.gateNumber}</span>
+							</header>
+							<section
+								className={clsx("pb-1", {
+									"border-b-prismatic": isFirstPlace,
+									"border-theme": !isFirstPlace,
+								})}
+							>
+								<h4
+									className={clsx(
+										"text-2xl text-theme leading-tight wrap-break-word",
+										{ "prismatic-text": isFirstPlace }
+									)}
+								>
+									{entry.displayName}
+								</h4>
+								{entry.role === "poll-editor" && (
+									<small className="text-xs text-gray-400 -mt-1 block">
+										{entry.role}
+									</small>
+								)}
+							</section>
+							<section
+								className={clsx("border-b text-sm flex gap-2 py-2", {
+									"border-b-prismatic border-b-4": isFirstPlace,
+									"border-theme": !isFirstPlace,
+								})}
+							>
+								<img
+									src={entry.photoUrl}
+									alt={`photo of ${entry.displayName}`}
+									className="w-full mb-2"
+								/>
+							</section>
+							<section
+								className={clsx(
+									"border-b text-sm gap-2 py-2 flex justify-center",
+									{
+										"border-b-prismatic border-b-4": isFirstPlace,
+										"border-theme": !isFirstPlace,
+									}
+								)}
+							>
+								{entry.level > 1 && (
+									<span className="text-rose-500">[L{entry.level}]</span>
+								)}
+								<p className="text-2xl flex gap-2 items-center">
+									{entry.displayCoverage}%{" "}
+									<span className="text-sm">coverage</span>
+								</p>
+							</section>
+							<section className="text-sm mt-2">
+								<p className="text-lg">Run stats</p>
+								<ul className="px-4 list-disc">
+									<li>correct polls: {entry.correctPolls}</li>
+									<li>best streak: {entry.bestStreak}</li>
+									<li>current streak: {entry.currentStreak}</li>
+								</ul>
+							</section>
+						</li>
+					);
+				})}
+			</ol>
+		</section>
+	);
+};

--- a/src/ui/ranking/SeasonInfo.ui.stories.tsx
+++ b/src/ui/ranking/SeasonInfo.ui.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SeasonInfo } from "./SeasonInfo.ui";
+
+const meta: Meta<typeof SeasonInfo> = {
+	component: SeasonInfo,
+	title: "Ranking/Atoms/Season Info",
+};
+export default meta;
+
+type Story = StoryObj<typeof SeasonInfo>;
+
+export const ManyDaysLeft: Story = {
+	args: {
+		name: "Season 1: Core Loop",
+		daysRemaining: 14,
+	},
+};
+
+export const OneDayLeft: Story = {
+	args: {
+		name: "Season 1: Core Loop",
+		daysRemaining: 1,
+	},
+};
+
+export const EndsToday: Story = {
+	args: {
+		name: "Season 1: Core Loop",
+		daysRemaining: 0,
+	},
+};

--- a/src/ui/ranking/SeasonInfo.ui.tsx
+++ b/src/ui/ranking/SeasonInfo.ui.tsx
@@ -1,0 +1,19 @@
+type SeasonInfoProps = {
+	name: string;
+	daysRemaining: number;
+};
+
+export const SeasonInfo = ({ name, daysRemaining }: SeasonInfoProps) => (
+	<div>
+		<h3 className="text-lg font-semibold text-theme mb-2">{name}</h3>
+		<div className="text-xs text-white">
+			{daysRemaining === 0 ? (
+				<span className="text-red-400">Ends today!</span>
+			) : daysRemaining === 1 ? (
+				<span className="text-yellow-400">Ends in 1 day</span>
+			) : (
+				<span>Ends in {daysRemaining} days</span>
+			)}
+		</div>
+	</div>
+);

--- a/src/ui/runs/CategoryCoverageGrid.ui.stories.tsx
+++ b/src/ui/runs/CategoryCoverageGrid.ui.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CategoryCoverageGridUI } from "./CategoryCoverageGrid.ui";
+
+const meta: Meta<typeof CategoryCoverageGridUI> = {
+	component: CategoryCoverageGridUI,
+	title: "Runs/Organisms/Category Coverage Grid",
+	decorators: [
+		(Story) => (
+			<div className="max-w-2xl p-4">
+				<Story />
+			</div>
+		),
+	],
+};
+export default meta;
+
+type Story = StoryObj<typeof CategoryCoverageGridUI>;
+
+const baseEntries = [
+	{
+		code: "js",
+		name: "JavaScript",
+		currentCoverage: 42.5,
+		currentStreak: 3,
+		bestStreak: 7,
+		isBestStreak: true,
+		isCurrent: false,
+	},
+	{
+		code: "ts",
+		name: "TypeScript",
+		currentCoverage: 28.0,
+		currentStreak: 1,
+		bestStreak: 4,
+		isBestStreak: false,
+		isCurrent: false,
+	},
+	{
+		code: "pokemon",
+		name: "Pokémon",
+		currentCoverage: 15.3,
+		currentStreak: 0,
+		bestStreak: 2,
+		isBestStreak: false,
+		isCurrent: false,
+	},
+	{
+		code: "bk",
+		name: "Banjo-Kazooie",
+		currentCoverage: 5.0,
+		currentStreak: 0,
+		bestStreak: 1,
+		isBestStreak: false,
+		isCurrent: false,
+	},
+];
+
+export const Default: Story = {
+	args: { entries: baseEntries },
+};
+
+export const WithCurrentCategory: Story = {
+	args: {
+		entries: baseEntries.map((e) => ({
+			...e,
+			isCurrent: e.code === "ts",
+		})),
+	},
+};
+
+export const AllZero: Story = {
+	args: {
+		entries: baseEntries.map((e) => ({
+			...e,
+			currentCoverage: 0,
+			currentStreak: 0,
+			bestStreak: 0,
+			isBestStreak: false,
+		})),
+	},
+};

--- a/src/ui/runs/CategoryCoverageGrid.ui.tsx
+++ b/src/ui/runs/CategoryCoverageGrid.ui.tsx
@@ -1,0 +1,71 @@
+import { clsx } from "clsx";
+
+export type CategoryCoverageEntry = {
+	code: string;
+	name: string;
+	currentCoverage: number;
+	currentStreak: number;
+	bestStreak: number;
+	isBestStreak: boolean;
+	isCurrent: boolean;
+};
+
+type CategoryCoverageGridUIProps = {
+	entries: CategoryCoverageEntry[];
+};
+
+export const CategoryCoverageGridUI = ({
+	entries,
+}: CategoryCoverageGridUIProps) => (
+	<div className="space-y-2">
+		<h3 className="text-xl">Coverage score overview</h3>
+
+		<div className="grid grid-cols-4 gap-2 text-sm border-b border-theme pb-2">
+			<span>Category</span>
+			<span>Coverage</span>
+			<span>Streak</span>
+			<span>Best Streak</span>
+		</div>
+
+		<div className="space-y-1">
+			{entries.map((entry) => (
+				<div
+					key={entry.code}
+					className={clsx("grid grid-cols-4 gap-2 text-sm pl-2", {
+						"bg-theme/10 border-l-4 border-theme": entry.isCurrent,
+						"hover:bg-gray-800/50": !entry.isCurrent,
+					})}
+					aria-current={entry.isCurrent ? "true" : undefined}
+				>
+					<span
+						className={clsx("self-center", { "text-theme": entry.isCurrent })}
+					>
+						{entry.name}
+					</span>
+					<div className="flex flex-col gap-0">
+						<span className={clsx({ "text-theme": entry.isCurrent })}>
+							{entry.currentCoverage.toFixed(1)}%
+						</span>
+						<meter
+							className="w-full h-2"
+							min="0"
+							max="100"
+							value={entry.currentCoverage}
+						/>
+					</div>
+					<span
+						className={clsx("self-center", { "text-theme": entry.isCurrent })}
+					>
+						{entry.currentStreak}
+					</span>
+					<span
+						className={clsx("self-center", { "text-theme": entry.isCurrent })}
+					>
+						{entry.isBestStreak && entry.bestStreak > 0 && <>★ </>}
+						{entry.bestStreak}
+					</span>
+				</div>
+			))}
+		</div>
+	</div>
+);

--- a/src/ui/runs/GateHealth.ui.stories.tsx
+++ b/src/ui/runs/GateHealth.ui.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { GateHealth } from "./GateHealth.ui";
+
+const meta: Meta<typeof GateHealth> = {
+	component: GateHealth,
+	title: "Runs/Organisms/Gate Health",
+	decorators: [
+		(Story) => (
+			<div className="max-w-sm p-4 border border-theme">
+				<Story />
+			</div>
+		),
+	],
+};
+export default meta;
+
+type Story = StoryObj<typeof GateHealth>;
+
+export const AllInProgress: Story = {
+	args: {
+		gateNumber: 3,
+		pollsLeft: 2,
+		slots: [
+			{
+				id: "coverage-1",
+				status: "in-progress",
+				label: "Coverage Gain",
+				difficulty: "medium",
+				requirement: "Gain 2% in 5 polls",
+				currentStat: "Current: +1.4%",
+			},
+			{
+				id: "correct-1",
+				status: "in-progress",
+				label: "Correct Answers",
+				difficulty: "low",
+				requirement: "3 of 5 correct",
+				currentStat: "Current: 2 correct",
+			},
+		],
+	},
+};
+
+export const Mixed: Story = {
+	args: {
+		gateNumber: 5,
+		pollsLeft: 0,
+		slots: [
+			{
+				id: "coverage-1",
+				status: "passed",
+				label: "Coverage Gain",
+				difficulty: "medium",
+				requirement: "Gain 2% in 5 polls",
+			},
+			{
+				id: "correct-1",
+				status: "failed",
+				label: "Short Window",
+				difficulty: "high",
+				requirement: "All 3 polls correct",
+			},
+			{
+				id: "mastery-1",
+				status: "skipped",
+				label: "Category Mastery",
+				difficulty: "critical",
+				requirement: "All JS polls correct",
+			},
+		],
+	},
+};
+
+export const SinglePollLeft: Story = {
+	args: {
+		gateNumber: 1,
+		pollsLeft: 1,
+		slots: [
+			{
+				id: "coverage-1",
+				status: "in-progress",
+				label: "Coverage Gain",
+				difficulty: "low",
+				requirement: "Gain 1% in 5 polls",
+				currentStat: "Current: +0.8%",
+			},
+		],
+	},
+};

--- a/src/ui/runs/GateHealth.ui.tsx
+++ b/src/ui/runs/GateHealth.ui.tsx
@@ -1,0 +1,69 @@
+import {
+	DIFFICULTY_CLASSES,
+	STATUS_ICON,
+	type Difficulty,
+	type SlotStatus,
+} from "./pipelineStyles";
+
+export type GateSlotDisplay = {
+	id: string;
+	status: SlotStatus;
+	label: string;
+	difficulty: Difficulty;
+	requirement: string;
+	currentStat?: string;
+};
+
+const STATUS_LABEL: Record<SlotStatus, React.ReactNode> = {
+	"in-progress": <span className="text-yellow-400">in progress</span>,
+	passed: <span className="text-green-400">passed</span>,
+	failed: <span className="text-red-400">failed</span>,
+	skipped: <span className="text-zinc-500">skipped</span>,
+};
+
+export type GateHealthProps = {
+	gateNumber: number;
+	pollsLeft: number;
+	slots: GateSlotDisplay[];
+};
+
+export const GateHealth = ({
+	gateNumber,
+	pollsLeft,
+	slots,
+}: GateHealthProps) => (
+	<div className="border-t border-theme pt-4 space-y-3">
+		<div className="flex items-baseline justify-between">
+			<p className="text-xl">Gate #{gateNumber}</p>
+			<p className="text-base text-zinc-500">
+				{pollsLeft} poll{pollsLeft !== 1 ? "s" : ""} left
+			</p>
+		</div>
+		<ul className="space-y-3">
+			{slots.map((slot) => (
+				<li key={slot.id} className="flex items-start gap-2">
+					<span className="mt-1">{STATUS_ICON[slot.status]}</span>
+					<div className="min-w-0">
+						<p className={`text-base ${DIFFICULTY_CLASSES[slot.difficulty]}`}>
+							{slot.label}
+						</p>
+						<p className="text-base text-zinc-500">
+							Risk:{" "}
+							<span className={DIFFICULTY_CLASSES[slot.difficulty]}>
+								{slot.difficulty}
+							</span>
+							{" · "}
+							{slot.requirement}
+						</p>
+						<p className="text-base text-zinc-500">
+							{STATUS_LABEL[slot.status]}
+						</p>
+						{slot.currentStat && slot.status === "in-progress" && (
+							<p className="text-base text-zinc-300">{slot.currentStat}</p>
+						)}
+					</div>
+				</li>
+			))}
+		</ul>
+	</div>
+);

--- a/src/ui/runs/PipelineDisplay.ui.stories.tsx
+++ b/src/ui/runs/PipelineDisplay.ui.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { PipelineDisplay } from "./PipelineDisplay.ui";
+
+const meta: Meta<typeof PipelineDisplay> = {
+	component: PipelineDisplay,
+	title: "Runs/Organisms/Pipeline Display",
+	decorators: [
+		(Story) => (
+			<div className="max-w-lg">
+				<Story />
+			</div>
+		),
+	],
+};
+export default meta;
+
+type Story = StoryObj<typeof PipelineDisplay>;
+
+const inProgressSlots = [
+	{
+		id: "coverage-1",
+		status: "in-progress" as const,
+		label: "Coverage Gain",
+		difficulty: "medium" as const,
+		requirement: "Gain 2% in 5 polls",
+		reward: "+64 KB",
+	},
+	{
+		id: "correct-1",
+		status: "in-progress" as const,
+		label: "Correct Answers",
+		difficulty: "low" as const,
+		requirement: "Answer 3 of 5 correctly",
+		reward: "+32 KB",
+	},
+];
+
+export const InProgress: Story = {
+	args: {
+		slots: inProgressSlots,
+		pollsRemaining: 3,
+	},
+};
+
+export const EvaluatedPassed: Story = {
+	args: {
+		slots: [
+			{ ...inProgressSlots[0], status: "passed" },
+			{ ...inProgressSlots[1], status: "passed" },
+		],
+		evaluation: { passed: true, totalReward: "+96 KB" },
+	},
+};
+
+export const EvaluatedFailed: Story = {
+	args: {
+		slots: [
+			{ ...inProgressSlots[0], status: "passed" },
+			{
+				id: "short-1",
+				status: "failed" as const,
+				label: "Short Window",
+				difficulty: "high" as const,
+				requirement: "All 3 polls correct",
+				reward: "+128 KB",
+			},
+		],
+		evaluation: { passed: false, totalReward: "+0 KB" },
+	},
+};
+
+export const AllDifficulties: Story = {
+	args: {
+		slots: [
+			{
+				id: "s1",
+				status: "passed" as const,
+				label: "Coverage Gain",
+				difficulty: "low" as const,
+				requirement: "Gain 1% in 5 polls",
+				reward: "+32 KB",
+			},
+			{
+				id: "s2",
+				status: "in-progress" as const,
+				label: "Correct Answers",
+				difficulty: "medium" as const,
+				requirement: "3 of 5 correct",
+				reward: "+64 KB",
+			},
+			{
+				id: "s3",
+				status: "failed" as const,
+				label: "Short Window",
+				difficulty: "high" as const,
+				requirement: "All 3 correct",
+				reward: "+128 KB",
+			},
+			{
+				id: "s4",
+				status: "skipped" as const,
+				label: "Category Mastery",
+				difficulty: "critical" as const,
+				requirement: "All JS polls correct",
+				reward: "+256 KB",
+			},
+		],
+		evaluation: { passed: false, totalReward: "+0 KB" },
+	},
+};

--- a/src/ui/runs/PipelineDisplay.ui.tsx
+++ b/src/ui/runs/PipelineDisplay.ui.tsx
@@ -1,0 +1,110 @@
+import {
+	DIFFICULTY_CLASSES,
+	STATUS_ICON,
+	type Difficulty,
+	type SlotStatus,
+} from "./pipelineStyles";
+
+export type PipelineSlotDisplay = {
+	id: string;
+	status: SlotStatus;
+	label: string;
+	difficulty: Difficulty;
+	requirement: string;
+	reward: string;
+};
+
+type SlotGroup = {
+	status: SlotStatus;
+	label: string;
+	entries: PipelineSlotDisplay[];
+};
+
+const GROUP_LABEL: Record<SlotStatus, string> = {
+	"in-progress": "in progress",
+	passed: "successful",
+	failed: "failing",
+	skipped: "skipped",
+};
+
+const SlotRow = ({ slot }: { slot: PipelineSlotDisplay }) => (
+	<li className="flex items-center gap-2 text-sm">
+		<span className="inline-flex items-center justify-center w-4 h-4 shrink-0">
+			{STATUS_ICON[slot.status]}
+		</span>
+		<span className="text-gray-200 w-28 shrink-0">{slot.label}</span>
+		<span
+			className={`text-xs border px-1 shrink-0 ${DIFFICULTY_CLASSES[slot.difficulty]}`}
+		>
+			{slot.difficulty}
+		</span>
+		<span className="text-gray-400 flex-1 text-xs">{slot.requirement}</span>
+		<span className="text-emerald-400 text-xs whitespace-nowrap shrink-0">
+			{slot.reward}
+		</span>
+	</li>
+);
+
+export type PipelineDisplayProps = {
+	slots: PipelineSlotDisplay[];
+	pollsRemaining?: number;
+	evaluation?: {
+		passed: boolean;
+		totalReward: string;
+	};
+};
+
+export const PipelineDisplay = ({
+	slots,
+	pollsRemaining,
+	evaluation,
+}: PipelineDisplayProps) => {
+	if (slots.length === 0) return null;
+
+	const groups = (
+		["in-progress", "passed", "failed", "skipped"] as SlotStatus[]
+	)
+		.map((status) => ({
+			status,
+			label: GROUP_LABEL[status],
+			entries: slots.filter((s) => s.status === status),
+		}))
+		.filter((g): g is SlotGroup => g.entries.length > 0);
+
+	return (
+		<div>
+			{pollsRemaining !== undefined && !evaluation && (
+				<p className="text-white text-md mb-2">
+					{pollsRemaining} polls left until gate evaluation
+				</p>
+			)}
+
+			{groups.map(({ status, label, entries }) => (
+				<div key={status}>
+					{evaluation && (
+						<p className="text-gray-400 text-xs mt-2 mb-1 flex items-center gap-1.5">
+							{STATUS_ICON[status]}
+							{entries.length} {label}{" "}
+							{entries.length === 1 ? "check" : "checks"}
+						</p>
+					)}
+					<ul className="flex flex-col gap-2">
+						{entries.map((slot) => (
+							<SlotRow key={slot.id} slot={slot} />
+						))}
+					</ul>
+				</div>
+			))}
+
+			{evaluation && (
+				<p
+					className={`mt-3 text-xs ${evaluation.passed ? "text-green-400" : "text-red-400"}`}
+				>
+					{evaluation.passed
+						? `▶ Pipeline passed — ${evaluation.totalReward} storage`
+						: "▶ Pipeline failed"}
+				</p>
+			)}
+		</div>
+	);
+};

--- a/src/ui/runs/PipelineUpgrade.ui.stories.tsx
+++ b/src/ui/runs/PipelineUpgrade.ui.stories.tsx
@@ -1,0 +1,140 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CurrentPipelineUI, PipelineUpgradeUI } from "./PipelineUpgrade.ui";
+
+// — CurrentPipelineUI —
+
+const currentPipelineMeta: Meta<typeof CurrentPipelineUI> = {
+	component: CurrentPipelineUI,
+	title: "Runs/Organisms/Current Pipeline",
+	decorators: [
+		(Story) => (
+			<div className="max-w-xl p-4">
+				<Story />
+			</div>
+		),
+	],
+};
+export default currentPipelineMeta;
+
+type CurrentStory = StoryObj<typeof CurrentPipelineUI>;
+
+const inProgressSlots = [
+	{
+		id: "coverage-1",
+		status: "in-progress" as const,
+		label: "Coverage Gain Pipeline",
+		difficulty: "medium" as const,
+		requirement: "Gain 2% coverage",
+		reward: "+64 KB",
+		currentStat: "+1.4% of 2% needed",
+	},
+	{
+		id: "correct-1",
+		status: "in-progress" as const,
+		label: "Correct Answer Pipeline",
+		difficulty: "low" as const,
+		requirement: "3/5 correct",
+		reward: "+32 KB",
+		currentStat: "2/3 correct",
+	},
+];
+
+export const LiveView: CurrentStory = {
+	args: {
+		gateNumber: 3,
+		pollsLeft: 2,
+		totalPotentialReward: "+96 KB",
+		slots: inProgressSlots,
+	},
+};
+
+export const EvaluationPassed: CurrentStory = {
+	args: {
+		gateNumber: 3,
+		slots: [
+			{ ...inProgressSlots[0], status: "passed" },
+			{ ...inProgressSlots[1], status: "passed" },
+		],
+		evaluation: { passed: true, totalReward: "+96 KB" },
+	},
+};
+
+export const EvaluationFailed: CurrentStory = {
+	args: {
+		gateNumber: 5,
+		slots: [
+			{ ...inProgressSlots[0], status: "passed" },
+			{
+				id: "mastery-1",
+				status: "failed" as const,
+				label: "Category Mastery Pipeline",
+				difficulty: "critical" as const,
+				requirement: "All Banjo-Kazooie polls correct",
+				reward: "+256 KB",
+			},
+		],
+		evaluation: { passed: false, totalReward: "+0 KB" },
+	},
+};
+
+export const WithSkipped: CurrentStory = {
+	args: {
+		gateNumber: 7,
+		slots: [
+			{ ...inProgressSlots[0], status: "passed" },
+			{
+				id: "mastery-1",
+				status: "skipped" as const,
+				label: "Category Mastery Pipeline",
+				difficulty: "critical" as const,
+				requirement: "All Pokémon polls correct",
+				reward: "+128 KB",
+			},
+		],
+		evaluation: { passed: true, totalReward: "+64 KB" },
+	},
+};
+
+// — PipelineUpgradeUI (separate export via named export trick) —
+
+export const UpgradeView: StoryObj<typeof PipelineUpgradeUI> = {
+	render: () => (
+		<div className="max-w-2xl p-4">
+			<PipelineUpgradeUI
+				isPending={false}
+				pipelineSection={
+					<CurrentPipelineUI
+						gateNumber={3}
+						pollsLeft={0}
+						slots={[
+							{ ...inProgressSlots[0], status: "passed" },
+							{ ...inProgressSlots[1], status: "passed" },
+						]}
+						evaluation={{ passed: true, totalReward: "+96 KB" }}
+					/>
+				}
+				upgradeCards={[
+					{
+						kind: "upgrade-slot",
+						label: "Coverage Gain Pipeline",
+						difficulty: "medium",
+						upgradeTo: "high",
+						requirement: "Gain 3% coverage",
+						reward: "+128 KB",
+						onSelect: () => {},
+					},
+				]}
+				addSlotCards={[
+					{
+						kind: "add-slot",
+						label: "Cold Start Pipeline",
+						difficulty: "high",
+						requirement: "First poll correct",
+						reward: "+96 KB",
+						onSelect: () => {},
+					},
+				]}
+			/>
+		</div>
+	),
+};

--- a/src/ui/runs/PipelineUpgrade.ui.tsx
+++ b/src/ui/runs/PipelineUpgrade.ui.tsx
@@ -1,0 +1,262 @@
+import {
+	DIFFICULTY_CLASSES,
+	STATUS_ICON,
+	type Difficulty,
+	type SlotStatus,
+} from "./pipelineStyles";
+
+export type { Difficulty, SlotStatus };
+
+const GROUP_LABEL: Record<SlotStatus, string> = {
+	"in-progress": "in progress",
+	passed: "successful",
+	failed: "failing",
+	skipped: "skipped",
+};
+
+const RewardBadge = ({ reward }: { reward: string }) => (
+	<span className="text-emerald-400 text-xs whitespace-nowrap">{reward}</span>
+);
+
+const DifficultyLabel = ({
+	difficulty,
+	text,
+}: {
+	difficulty: Difficulty;
+	text?: string;
+}) => (
+	<span className={DIFFICULTY_CLASSES[difficulty]}>
+		{text && <span className="text-white">{text}</span>} {difficulty}
+	</span>
+);
+
+// — Current Pipeline —
+
+export type CurrentPipelineSlot = {
+	id: string;
+	status: SlotStatus;
+	label: string;
+	difficulty: Difficulty;
+	requirement: string;
+	reward: string;
+	currentStat?: string;
+};
+
+export type CurrentPipelineUIProps = {
+	gateNumber?: number;
+	pollsLeft?: number;
+	totalPotentialReward?: string;
+	evaluation?: {
+		passed: boolean;
+		totalReward: string;
+	};
+	slots: CurrentPipelineSlot[];
+};
+
+export const CurrentPipelineUI = ({
+	gateNumber,
+	pollsLeft,
+	totalPotentialReward,
+	evaluation,
+	slots,
+}: CurrentPipelineUIProps) => {
+	const groups = (
+		["in-progress", "passed", "failed", "skipped"] as SlotStatus[]
+	)
+		.map((status) => ({
+			status,
+			entries: slots.filter((s) => s.status === status),
+		}))
+		.filter((g) => g.entries.length > 0);
+
+	return (
+		<div className="border border-white">
+			<div className="border-b border-white px-4 py-3">
+				<div className="flex items-baseline justify-between">
+					<p className="text-2xl">CI Pipelines</p>
+					{gateNumber !== undefined && (
+						<span className="text-xl">Gate #{gateNumber}</span>
+					)}
+				</div>
+				<p className="text-zinc-300 text-sm mt-0.5">
+					{pollsLeft !== undefined && (
+						<>
+							<span>{pollsLeft} polls left until next gate check</span>
+							{" · "}
+						</>
+					)}
+					{slots.length} active {slots.length === 1 ? "check" : "checks"} · all
+					<span className="text-yellow-400"> pending</span> checks must pass
+				</p>
+				{!evaluation && totalPotentialReward && (
+					<p className="text-sm mt-1">
+						Total reward if all pass:{" "}
+						<RewardBadge reward={totalPotentialReward} />
+					</p>
+				)}
+			</div>
+
+			{evaluation?.passed && (
+				<div className="bg-emerald-950/40 border-b border-emerald-500/50 px-4 py-3">
+					<p className="text-emerald-300 text-lg">
+						✓ Pipeline cleared — {evaluation.totalReward} storage added to your
+						limit
+					</p>
+				</div>
+			)}
+
+			{groups.map(({ status, entries }) => (
+				<div key={status}>
+					{evaluation && (
+						<div className="px-4 py-2 border-b border-white bg-white/5 flex items-center gap-2 text-sm text-gray-400">
+							{STATUS_ICON[status]}
+							<span>
+								{entries.length} {GROUP_LABEL[status]}{" "}
+								{entries.length === 1 ? "check" : "checks"}
+							</span>
+						</div>
+					)}
+					{entries.map((slot) => (
+						<section
+							key={slot.id}
+							className="flex items-start gap-3 border-b border-white last:border-b-0 px-4 py-3"
+						>
+							<span className="mt-0.5 shrink-0">{STATUS_ICON[status]}</span>
+							<div>
+								<p>
+									<span className={DIFFICULTY_CLASSES[slot.difficulty]}>
+										{slot.label}
+									</span>
+								</p>
+								<DifficultyLabel text="Risk:" difficulty={slot.difficulty} />
+								{" · "}
+								Requirement: {slot.requirement}
+								{" · "}
+								Reward: <RewardBadge reward={slot.reward} />
+								{slot.currentStat && slot.status === "in-progress" && (
+									<p>
+										Current:{" "}
+										<span className="text-gray-300">{slot.currentStat}</span>
+									</p>
+								)}
+							</div>
+						</section>
+					))}
+				</div>
+			))}
+		</div>
+	);
+};
+
+// — Pipeline Upgrade —
+
+export type UpgradeCardDisplay = {
+	kind: "upgrade-slot" | "add-slot";
+	label: string;
+	difficulty: Difficulty;
+	upgradeTo?: Difficulty;
+	requirement: string;
+	reward: string;
+	onSelect: () => void;
+};
+
+export type PipelineUpgradeUIProps = {
+	pipelineSection: React.ReactNode;
+	upgradeCards: UpgradeCardDisplay[];
+	addSlotCards: UpgradeCardDisplay[];
+	isPending: boolean;
+};
+
+const CardEntry = ({
+	card,
+	isPending,
+}: {
+	card: UpgradeCardDisplay;
+	isPending: boolean;
+}) => (
+	<div className="border border-white p-4 space-y-1">
+		<div className="flex items-center gap-2 mb-2">
+			<span className="text-zinc-300">
+				{card.kind === "upgrade-slot" ? "↑" : "+"}
+			</span>
+			<span>{card.label} · </span>
+			<DifficultyLabel difficulty={card.difficulty} />
+			{card.upgradeTo && (
+				<DifficultyLabel text="→" difficulty={card.upgradeTo} />
+			)}
+		</div>
+		<p className="text-zinc-300 text-sm pl-4">
+			Requirement: <span className="text-gray-200">{card.requirement}</span>
+		</p>
+		<p className="text-zinc-300 text-sm pl-4">
+			Reward on pass: <RewardBadge reward={card.reward} />
+		</p>
+		<div className="pl-4 pt-2">
+			<button
+				onClick={card.onSelect}
+				disabled={isPending}
+				className="border border-white px-4 py-2 text-lg text-white hover:bg-white hover:text-black transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+			>
+				Select
+			</button>
+		</div>
+	</div>
+);
+
+const SectionHeader = ({
+	title,
+	subtitle,
+}: {
+	title: string;
+	subtitle: string;
+}) => (
+	<div className="border border-white px-4 py-3">
+		<h1 className="text-2xl">{title}</h1>
+		<p className="text-zinc-300 text-xs mt-0.5">{subtitle}</p>
+	</div>
+);
+
+export const PipelineUpgradeUI = ({
+	pipelineSection,
+	upgradeCards,
+	addSlotCards,
+	isPending,
+}: PipelineUpgradeUIProps) => (
+	<div>
+		<div className="mb-4">
+			<h2 className="text-green-400 text-4xl">Pipeline check passed!</h2>
+			<span>Select a new pipeline or upgrade an existing one.</span>
+		</div>
+		<div className="space-y-6">
+			{pipelineSection}
+
+			<section className="flex flex-col gap-6">
+				{upgradeCards.length > 0 && (
+					<div className="space-y-4">
+						<SectionHeader
+							title="Modify Existing Slots"
+							subtitle="Increase difficulty, higher reward, higher risk"
+						/>
+						{upgradeCards.map((card, i) => (
+							<CardEntry key={i} card={card} isPending={isPending} />
+						))}
+					</div>
+				)}
+
+				{addSlotCards.length > 0 && (
+					<div className="space-y-4">
+						<SectionHeader
+							title="Add New Slot"
+							subtitle="More constraints, harder to pass all"
+						/>
+						<div className="grid grid-cols-1 gap-4">
+							{addSlotCards.map((card, i) => (
+								<CardEntry key={i} card={card} isPending={isPending} />
+							))}
+						</div>
+					</div>
+				)}
+			</section>
+		</div>
+	</div>
+);

--- a/src/ui/runs/pipelineStyles.tsx
+++ b/src/ui/runs/pipelineStyles.tsx
@@ -1,0 +1,19 @@
+export type Difficulty = "low" | "medium" | "high" | "critical";
+
+export const DIFFICULTY_CLASSES: Record<Difficulty, string> = {
+	low: "text-blue-400 border-blue-400",
+	medium: "text-green-400 border-green-400",
+	high: "text-orange-400 border-orange-400",
+	critical: "text-red-500 border-red-500",
+};
+
+export type SlotStatus = "in-progress" | "passed" | "failed" | "skipped";
+
+export const STATUS_ICON: Record<SlotStatus, React.ReactNode> = {
+	"in-progress": (
+		<span className="w-2.5 h-2.5 rounded-full bg-yellow-400 animate-pulse inline-block" />
+	),
+	passed: <span className="text-green-400">✓</span>,
+	failed: <span className="text-red-400">✗</span>,
+	skipped: <span className="text-gray-500">⊘</span>,
+};


### PR DESCRIPTION
## Summary

Continues the UI layer refactor from PR #81, extracting HTML/CSS out of `src/domains/` into the presentational `src/ui/{domain}/` tier.

**Completed in this PR:**
- `ranking/`: `LeaderboardUI`, `SeasonInfo` — fully extracted and wired ✅
- `economy/`: `ConfigCard`, `ShopCard`, `StorageBreakdown` — extracted (partial) 🔄
- `runs/`: `GateHealth`, `PipelineDisplay` — extracted (partial) 🔄
- Storybook preview migrated to `.tsx` for JSX decorator support
- All existing stories updated for new preview setup

**Still remaining (not in this PR):**
- `economy/`: ArchiveSummary, AvatarPopover, BorderShop, ActiveCard, ConfigDeckFooter, ConfigVariantDialog, ExposedConfigDeckDisplay, ShopContainer
- `runs/`: PipelineUpgradeContainer, UpgradePipelineSection, CategoryCoverageGrid
- `polls/`: all components (largest domain, not yet started)
- `awards/`: AwardCard, AwardScoreBars, AwardsGrid
- `users/`: Auth, Avatar, Login, UserTitle

## Test plan

- [ ] Storybook runs and all stories render correctly
- [ ] Ranking pages (leaderboard, season info) render correctly in-app
- [ ] No TypeScript errors (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)