### PR TITLE
fix: wrap installed configs on overflow

### DIFF
--- a/src/domains/economy/components/ShopContainer.component.tsx
+++ b/src/domains/economy/components/ShopContainer.component.tsx
@@ -175,9 +175,9 @@ const ShopContainer = ({
 					{activeConfigs.length === 0 ? (
 						<p className="text-gray-400">No configs installed yet.</p>
 					) : (
-						<ul className="flex gap-4 overflow-x-auto snap-x snap-mandatory pb-2">
+						<ul className="flex flex-wrap gap-4">
 							{activeConfigs.map((config) => (
-								<li key={config.id} className="shrink-0 snap-start">
+								<li key={config.id}>
 									<ActiveCard
 										config={config}
 										size="small"


### PR DESCRIPTION
## Summary
- Installed configs list now wraps to a new row when cards don't fit, instead of scrolling horizontally
- Removed `overflow-x-auto`, `snap-x`, `snap-mandatory`, and `shrink-0` which were forcing horizontal scroll behaviour

## Test plan
- [ ] Install 2+ configs and verify they wrap to the next row when the container is narrow (mobile or narrow viewport)
- [ ] Verify deinstall still works on wrapped cards

https://claude.ai/code/session_011B5qbM3Ej1H5nBNFa5pNsh