### PR TITLE
Add Version 2.0 milestone and pre-2.0 QA story bean

### DIFF
--- a/.beans/DVTD-1sb7--swatch-config-alternate-core-pipeline-check-for-ha.md
+++ b/.beans/DVTD-1sb7--swatch-config-alternate-core-pipeline-check-for-ha.md
@@ -5,7 +5,8 @@ status: todo
 type: story
 priority: normal
 created_at: 2026-07-25T07:29:53Z
-updated_at: 2026-07-25T07:29:53Z
+updated_at: 2026-07-27T10:47:17Z
+parent: DVTD-nooj
 ---
 
 A "swatch" is a config/unlock that lets a player opt into a harder run variant. Installing it swaps in a second "core" pipeline check — parallel to the unit-test check — with its own pass/fail condition, so the run is judged against an additional gate rather than unit-test alone. Runs with a swatch installed should carry different (presumably richer) rewards to compensate for the added difficulty.

--- a/.beans/DVTD-1sb7--swatch-config-alternate-core-pipeline-check-for-ha.md
+++ b/.beans/DVTD-1sb7--swatch-config-alternate-core-pipeline-check-for-ha.md
@@ -1,0 +1,27 @@
+---
+# DVTD-1sb7
+title: Swatch config: alternate core pipeline check for harder runs
+status: todo
+type: story
+priority: normal
+created_at: 2026-07-25T07:29:53Z
+updated_at: 2026-07-25T07:29:53Z
+---
+
+A "swatch" is a config/unlock that lets a player opt into a harder run variant. Installing it swaps in a second "core" pipeline check — parallel to the unit-test check — with its own pass/fail condition, so the run is judged against an additional gate rather than unit-test alone. Runs with a swatch installed should carry different (presumably richer) rewards to compensate for the added difficulty.
+
+Sister bean: DVTD-klz2 (renames the unit-test core check terminology this idea builds on).
+
+## Open questions
+
+- [ ] What does a swatch actually check/require (its pass condition), distinct from unit-test?
+- [ ] How is a swatch unlocked (shop item, milestone unlock, discovery system)?
+- [ ] Can multiple swatches be active at once, or is it one alternate core check at a time?
+- [ ] What reward differential justifies the added difficulty (storage, cosmetics, exclusive configs)?
+- [ ] Does failing the swatch check end the run the same way failing unit-test does, or is it a softer penalty?
+
+## Todos
+
+- [ ] Brainstorm session to nail down swatch mechanics
+- [ ] Decide reward structure vs. unit-test-only runs
+- [ ] Spec out swatch as a new core pipeline check type alongside unit-test

--- a/.beans/DVTD-9r8p--game-balance-can-perks-only-play-skip-gates-entire.md
+++ b/.beans/DVTD-9r8p--game-balance-can-perks-only-play-skip-gates-entire.md
@@ -1,0 +1,28 @@
+---
+# DVTD-9r8p
+title: 'Game balance: can perks-only play skip gates entirely?'
+status: todo
+type: story
+priority: normal
+created_at: 2026-07-27T10:44:49Z
+updated_at: 2026-07-27T10:44:49Z
+parent: DVTD-bojz
+---
+
+Now that configs split into gates (judge you) and perks (help you), a balance question falls out directly: can a player just stack perks and coast through the game without ever engaging with a gate config, effectively cheating the intended challenge loop? And symmetrically — if a player *can* ignore gates, what's the actual incentive to install one beyond "it pays a bigger reward"? If reward-chasing is the only reason, gates risk being purely optional min-max bait rather than a meaningful judge of skill.
+
+## Open questions
+
+- [ ] Is it currently possible to clear a run/gate using only perks, with zero gate configs installed?
+- [ ] If yes — is that a problem, or is "perks-only, slower/safer" a legitimate playstyle (vs. "gates, higher risk/reward")?
+- [ ] Beyond higher reward KB, what else could make installing a gate config compelling — unlocks, required for certain pipelines, mandatory at higher gate numbers?
+- [ ] Should some pipelines/gates require at least one gate config installed, rather than leaving it fully optional?
+- [ ] Does "judge you" only matter if failing a gate has a real cost — what's the downside of a gate config today vs. just not installing one?
+- [ ] Is this a balance problem at all difficulty tiers, or only late-game once storage/perks compound?
+
+## Todos
+
+- [ ] Audit current configs against the gates/perks split (DVTD-bojz) to confirm which are actually gates today
+- [ ] Playtest/simulate a perks-only run to see how far it gets
+- [ ] Decide whether gates need a non-reward incentive (or restriction) to stay meaningful
+- [ ] Write up the decision as a follow-up to DVTD-bojz once resolved

--- a/.beans/DVTD-bojz--split-config-taxonomy-into-gates-vs-perks.md
+++ b/.beans/DVTD-bojz--split-config-taxonomy-into-gates-vs-perks.md
@@ -1,0 +1,32 @@
+---
+# DVTD-bojz
+title: Split config taxonomy into gates vs. perks
+status: todo
+type: story
+priority: normal
+created_at: 2026-07-27T10:42:56Z
+updated_at: 2026-07-27T10:42:56Z
+---
+
+Configs that go up for different reasons (difficulty ramp vs. player investment) currently look identical on screen. Reframe the taxonomy as two species instead of three: **gates** (things that judge you — Unit Tests, Coverage) and **perks** (things that help you — ESLint, Copilot). Reward KB is just what a gate pays out when cleared, not a separate config kind.
+
+## Design decisions
+
+- **Gates auto-scale, locked, un-sellable** — the rising floor. Player doesn't choose or manage them directly.
+- **Perks stay manual** — player chooses, upgrades, and sells them. This is "your investment."
+- **Coverage is a pure gate** — currently does double duty as both gate and reward, which is the main source of muddiness. Cleanest fix: treat it as a gate that pays out like any other gate, not a reward currency itself.
+- **Upgrades cost storage, not coverage** — keeps coverage pure as "the climb" and honors one-currency-per-job (storage buys/upgrades things, coverage measures progress).
+
+## Sister beans
+
+- DVTD-h9s5 (coverage-gated config upgrades) — that bean explores gating upgrades on coverage thresholds; this story's "upgrades cost storage, not coverage" decision runs counter to that and should be reconciled before both move forward.
+- DVTD-klz2 (unit-test → core pipeline check rename) and DVTD-1sb7 (swatch: alternate core pipeline check) — both describe things that fall under the "gates" species defined here.
+
+## Todos
+
+- [ ] Shop: split the load-out into two zones — inert/locked gates vs. clickable/mutable perks
+- [ ] Shop: show sell/upgrade affordances only on the perks (mutable) half
+- [ ] Shop: preview the gate's next-gate ramp so the rising floor reads as pressure
+- [ ] Reclassify existing configs (Unit Tests, Coverage, ESLint, Copilot, etc.) into gate vs. perk
+- [ ] Decide how reward KB payout is surfaced now that it's tied to gate-clear rather than being its own config
+- [ ] Reconcile with DVTD-h9s5 on whether coverage ever gates an upgrade, given upgrades should cost storage

--- a/.beans/DVTD-bojz--split-config-taxonomy-into-gates-vs-perks.md
+++ b/.beans/DVTD-bojz--split-config-taxonomy-into-gates-vs-perks.md
@@ -5,7 +5,8 @@ status: todo
 type: story
 priority: normal
 created_at: 2026-07-27T10:42:56Z
-updated_at: 2026-07-27T10:42:56Z
+updated_at: 2026-07-27T10:47:17Z
+parent: DVTD-nooj
 ---
 
 Configs that go up for different reasons (difficulty ramp vs. player investment) currently look identical on screen. Reframe the taxonomy as two species instead of three: **gates** (things that judge you — Unit Tests, Coverage) and **perks** (things that help you — ESLint, Copilot). Reward KB is just what a gate pays out when cleared, not a separate config kind.

--- a/.beans/DVTD-h9s5--coverage-gated-config-upgrades-eg-js-needs-20.md
+++ b/.beans/DVTD-h9s5--coverage-gated-config-upgrades-eg-js-needs-20.md
@@ -1,0 +1,28 @@
+---
+# DVTD-h9s5
+title: Coverage-gated config upgrades (e.g. .js needs 20%)
+status: todo
+type: story
+priority: normal
+created_at: 2026-07-25T20:56:36Z
+updated_at: 2026-07-25T20:56:36Z
+---
+
+Require category coverage before a specific config can be upgraded. E.g. the `.js` config's upgrade is locked until the player has 20% coverage in JavaScript; each upgradeable config would define its own category + threshold pair. Ties config power directly to demonstrated category mastery instead of storage/currency alone.
+
+Sister bean: DVTD-7oa7 (config-upgrade acquisition surface for Tech Debt) — that bean gates upgrades behind accepting Tech Debt; this one gates them behind coverage. The two gating conditions may end up combined (coverage threshold AND TD acceptance) or offered as alternate upgrade paths.
+
+## Open questions
+
+- [ ] Which configs get an upgrade path, and what's each one's coverage threshold?
+- [ ] Is the threshold per-category coverage (category the config boosts) or something else?
+- [ ] Does the requirement gate purchase, or unlock an "upgrade" action on an already-owned config?
+- [ ] Does losing coverage (if that's ever possible) re-lock an already-upgraded config?
+- [ ] How does this interact with DVTD-7oa7's TD-based upgrade cost — combined gate or separate path?
+
+## Todos
+
+- [ ] Pick the first config(s) to prototype this on
+- [ ] Define threshold values per config
+- [ ] Decide interaction with Tech Debt upgrade surface (DVTD-7oa7)
+- [ ] UI: show locked/unlocked state + progress toward threshold on config card

--- a/.beans/DVTD-h9s5--coverage-gated-config-upgrades-eg-js-needs-20.md
+++ b/.beans/DVTD-h9s5--coverage-gated-config-upgrades-eg-js-needs-20.md
@@ -5,7 +5,8 @@ status: todo
 type: story
 priority: normal
 created_at: 2026-07-25T20:56:36Z
-updated_at: 2026-07-25T20:56:36Z
+updated_at: 2026-07-27T10:47:17Z
+parent: DVTD-nooj
 ---
 
 Require category coverage before a specific config can be upgraded. E.g. the `.js` config's upgrade is locked until the player has 20% coverage in JavaScript; each upgradeable config would define its own category + threshold pair. Ties config power directly to demonstrated category mastery instead of storage/currency alone.

--- a/.beans/DVTD-jhgg--duolingo-style-learn-home-start-or-no-polls-left-d.md
+++ b/.beans/DVTD-jhgg--duolingo-style-learn-home-start-or-no-polls-left-d.md
@@ -1,0 +1,31 @@
+---
+# DVTD-jhgg
+title: 'Duolingo-style /learn home: start point and no-polls-left destination'
+status: todo
+type: story
+priority: normal
+created_at: 2026-07-27T11:22:44Z
+updated_at: 2026-07-27T11:22:44Z
+parent: DVTD-nooj
+---
+
+Introduce a `/learn` screen modeled on Duolingo's home path — a visual, always-there hub. Two ways it could land in the flow:
+
+1. **Start there.** New/returning players land on `/learn` first instead of going straight into a poll.
+2. **End there.** At minimum, once a player has answered everything currently available (the existing `waiting` run state — see DVTD-8), `/learn` becomes the destination instead of a dead-end "nothing to do" screen.
+
+Either way, this gives the "waiting" state somewhere purposeful to send the player, rather than just idling on the last poll/results screen.
+
+## Open questions
+
+- [ ] Start-screen or waiting-state destination, or both?
+- [ ] What does `/learn` actually show — a path/map of categories, progress, upcoming content, cosmetics? Or is it just a richer version of the current waiting state?
+- [ ] How does this relate to the existing `/pipelines`, `/progress`, and `/community` routes — does `/learn` replace one of them, sit alongside, or become the new default landing route?
+- [ ] Does this apply per-day (waiting for tomorrow's poll) or only in true "no content left" edge cases?
+
+## Todos
+
+- [ ] Decide start-vs-waiting-state scope (or both) before designing the screen
+- [ ] Sketch what `/learn` shows relative to existing routes
+- [ ] Identify where the current `waiting` state is handled today and what it shows now
+- [ ] Prototype `/learn` route

--- a/.beans/DVTD-klz2--pre-20-copy-audit-and-unit-test-core-pipeline-chec.md
+++ b/.beans/DVTD-klz2--pre-20-copy-audit-and-unit-test-core-pipeline-chec.md
@@ -1,0 +1,17 @@
+---
+# DVTD-klz2
+title: Pre-2.0 copy audit and unit-test core pipeline check
+status: todo
+type: story
+priority: normal
+created_at: 2026-07-25T07:29:53Z
+updated_at: 2026-07-25T07:29:53Z
+parent: DVTD-nooj
+---
+
+QA pass for the 2.0 milestone.
+
+## Todos
+
+- [ ] Check all copy across the app — is it understandable?
+- [ ] Change "unit-test" to be a core pipeline check, instead of "fixed"

--- a/.beans/DVTD-nooj--version-20.md
+++ b/.beans/DVTD-nooj--version-20.md
@@ -1,0 +1,8 @@
+---
+# DVTD-nooj
+title: Version 2.0
+status: draft
+type: milestone
+created_at: 2026-07-25T07:29:53Z
+updated_at: 2026-07-25T07:29:53Z
+---


### PR DESCRIPTION
Story covers a copy readability audit and reclassifying the unit-test
check as a core pipeline check instead of "fixed".