### PR TITLE
fix: show description, cost and refund on installed config cards

### DIFF
--- a/.beans/DVTD-w9zc--installed-config-cards-hide-description-cost-and-r.md
+++ b/.beans/DVTD-w9zc--installed-config-cards-hide-description-cost-and-r.md
@@ -1,0 +1,42 @@
+---
+# DVTD-w9zc
+title: Installed config cards hide description, cost and refund
+status: completed
+type: bug
+priority: normal
+created_at: 2026-08-18T14:06:32Z
+updated_at: 2026-08-18T14:10:07Z
+---
+
+The shop's "Installed configs" row renders `ConfigCard` at `size="small"`, and the
+small branch of `src/ui/economy/ConfigCard.ui.tsx` returns early with only the name
+and rarity. `ConfigCard.component.tsx` already passes `costLabel`, `refundLabel` and
+`description`, so they are silently dropped. A player cannot see what an installed
+config does, what it cost, or what it refunds without deinstalling it.
+
+`size="small"` is shared with `PollActiveConfigStrip.ui.tsx`, `PollOptionRow.ui.tsx`
+and `PipelineFailureScreen.ui.tsx`, so the small variant must not grow
+unconditionally. Adding an opt-in `showDetails` prop instead.
+
+## Todo
+- [x] Spec for the small variant with and without details
+- [x] `showDetails` prop on `ConfigCard.ui.tsx`, small branch renders cost/refund/description
+- [x] Thread through `ConfigCard.component.tsx` and `ActiveCard.component.tsx`
+- [x] Enable on the Installed configs row in `ShopContainer.component.tsx`
+- [x] Story for the new variant
+- [x] lint, typecheck, tests
+
+## Summary of Changes
+
+`src/ui/economy/ConfigCard.ui.tsx` gains an opt-in `showDetails` prop. The small branch now renders a single storage line (`Cost: X · Refund: Y`) and the description under a divider, and widens to `w-56` only when details are shown, so `PollActiveConfigStrip`, `PollOptionRow` and `PipelineFailureScreen` keep the bare compact card.
+
+`ConfigCard.component.tsx` and `ActiveCard.component.tsx` thread the prop through; `ShopContainer.component.tsx` sets it on the Installed configs row only.
+
+New `src/ui/economy/ConfigCard.spec.tsx` pins all four cases, including the negative one (bare small renders no cost/refund/description). Added a `SmallWithDetails` story.
+
+Branch `fix/installed-config-details` off main, in the `../devvoted-tanstack-config-details` worktree.
+
+### Left out
+
+- The Next package offers row still uses the bare small card. Out of scope; it has no Deinstall button, so cost is arguably more useful there than on installed configs.
+- Refund now appears twice on an installed card: in the storage line and in the `Deinstall (+X)` button (`REFUND_RATE = 0.5`). Kept because it was explicitly requested.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor shop design flow when skipping a shop
 - Added Ruby configs
 - Improve gate pathing visualizations
+- Installed configs in the shop now show what they do, what they cost, and what you get back when you deinstall them
 
 ## 1.3.0 - 2026-07-06
 ### Added

--- a/src/domains/economy/components/Cards/ActiveCard.component.tsx
+++ b/src/domains/economy/components/Cards/ActiveCard.component.tsx
@@ -11,6 +11,7 @@ type ActiveCardProps = {
 	disabled?: boolean;
 	onDeinstall?: (config: Config) => void;
 	size?: "small" | "large";
+	showDetails?: boolean;
 };
 
 const ActiveCard = ({
@@ -18,6 +19,7 @@ const ActiveCard = ({
 	disabled,
 	onDeinstall,
 	size = "large",
+	showDetails,
 }: ActiveCardProps) => {
 	const disabledStyles = clsx(disabled && "opacity-50 cursor-not-allowed");
 	const largeStyles = clsx(
@@ -27,7 +29,12 @@ const ActiveCard = ({
 		<div
 			className={clsx("flex flex-col gap-2", size === "large" && largeStyles)}
 		>
-			<ConfigCard config={config} disabled={disabled} size={size} />
+			<ConfigCard
+				config={config}
+				disabled={disabled}
+				size={size}
+				showDetails={showDetails}
+			/>
 			{onDeinstall && (
 				<button
 					onClick={() => !disabled && onDeinstall(config)}

--- a/src/domains/economy/components/Cards/ConfigCard.component.tsx
+++ b/src/domains/economy/components/Cards/ConfigCard.component.tsx
@@ -7,9 +7,15 @@ type ConfigProps = {
 	config: Config;
 	disabled?: boolean;
 	size?: "small" | "large";
+	showDetails?: boolean;
 };
 
-const ConfigCard = ({ config, disabled, size = "large" }: ConfigProps) => (
+const ConfigCard = ({
+	config,
+	disabled,
+	size = "large",
+	showDetails,
+}: ConfigProps) => (
 	<ConfigCardUI
 		name={config.name}
 		rarity={config.rarity}
@@ -18,6 +24,7 @@ const ConfigCard = ({ config, disabled, size = "large" }: ConfigProps) => (
 		costLabel={formatStorage(config.cost)}
 		refundLabel={formatStorage(calculateRefund(config.cost))}
 		description={config.description}
+		showDetails={showDetails}
 	/>
 );
 

--- a/src/domains/economy/components/ShopContainer.component.tsx
+++ b/src/domains/economy/components/ShopContainer.component.tsx
@@ -181,6 +181,7 @@ const ShopContainer = ({
 									<ActiveCard
 										config={config}
 										size="small"
+										showDetails
 										onDeinstall={onDeinstallConfig}
 										disabled={!isOpen || deinstallConfigMutation.isPending}
 									/>

--- a/src/ui/economy/ConfigCard.spec.tsx
+++ b/src/ui/economy/ConfigCard.spec.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ConfigCard } from "./ConfigCard.ui";
+
+const CODE_COVERAGE = {
+	name: "Code Coverage",
+	rarity: "common",
+	costLabel: "128 KB",
+	refundLabel: "64 KB",
+	description: "Adds 1% coverage per correct answer in this category.",
+} as const;
+
+describe("ConfigCard", () => {
+	it("renders name and rarity only in the small size", () => {
+		render(<ConfigCard {...CODE_COVERAGE} size="small" />);
+
+		expect(screen.getByText("Code Coverage")).toBeInTheDocument();
+		expect(screen.getByText("(common)")).toBeInTheDocument();
+		expect(screen.queryByText(/Cost/)).not.toBeInTheDocument();
+		expect(screen.queryByText(/Refund/)).not.toBeInTheDocument();
+		expect(
+			screen.queryByText(CODE_COVERAGE.description)
+		).not.toBeInTheDocument();
+	});
+
+	it("renders cost, refund and description in the small size when details are shown", () => {
+		render(<ConfigCard {...CODE_COVERAGE} size="small" showDetails />);
+
+		expect(
+			screen.getByText("Cost: 128 KB · Refund: 64 KB")
+		).toBeInTheDocument();
+		expect(screen.getByText(CODE_COVERAGE.description)).toBeInTheDocument();
+	});
+
+	it("omits the storage line in the small size when neither cost nor refund is known", () => {
+		render(
+			<ConfigCard
+				name="Code Coverage"
+				rarity="common"
+				size="small"
+				showDetails
+				description={CODE_COVERAGE.description}
+			/>
+		);
+
+		expect(screen.queryByText(/Cost/)).not.toBeInTheDocument();
+		expect(screen.getByText(CODE_COVERAGE.description)).toBeInTheDocument();
+	});
+
+	it("renders cost, refund and description in the large size", () => {
+		render(<ConfigCard {...CODE_COVERAGE} size="large" />);
+
+		expect(screen.getByText("Cost: 128 KB")).toBeInTheDocument();
+		expect(screen.getByText("Refund: 64 KB")).toBeInTheDocument();
+		expect(screen.getByText(CODE_COVERAGE.description)).toBeInTheDocument();
+	});
+});

--- a/src/ui/economy/ConfigCard.stories.tsx
+++ b/src/ui/economy/ConfigCard.stories.tsx
@@ -18,6 +18,18 @@ export const Small: Story = {
 	},
 };
 
+export const SmallWithDetails: Story = {
+	args: {
+		name: ".includes",
+		rarity: "rare",
+		size: "small",
+		showDetails: true,
+		costLabel: "128 KB",
+		refundLabel: "64 KB",
+		description: "Reveals how many correct answers you have selected.",
+	},
+};
+
 export const Large: Story = {
 	args: {
 		name: "Prettier",

--- a/src/ui/economy/ConfigCard.ui.tsx
+++ b/src/ui/economy/ConfigCard.ui.tsx
@@ -11,6 +11,7 @@ type ConfigCardProps = {
 	costLabel?: string;
 	refundLabel?: string;
 	description?: string;
+	showDetails?: boolean;
 };
 
 export const ConfigCard = ({
@@ -21,16 +22,40 @@ export const ConfigCard = ({
 	costLabel,
 	refundLabel,
 	description,
+	showDetails,
 }: ConfigCardProps) => {
 	const color = RARITY_COLORS[rarity];
 
 	if (size === "small") {
+		const storageLine = [
+			costLabel && `Cost: ${costLabel}`,
+			refundLabel && `Refund: ${refundLabel}`,
+		]
+			.filter(Boolean)
+			.join(" · ");
+
 		return (
-			<article className={clsx("border min-w-40 p-2", color.border, color.bg)}>
+			<article
+				className={clsx(
+					"border p-2",
+					showDetails ? "w-56" : "min-w-40",
+					color.border,
+					color.bg,
+					disabled && "opacity-50 cursor-not-allowed"
+				)}
+			>
 				<div className="flex gap-2 place-items-center">
 					<h3 className={clsx("text-base", color.text)}>{name}</h3>
 					<span className={clsx("text-xs", color.text)}>({rarity})</span>
 				</div>
+				{showDetails && storageLine && (
+					<p className="text-sm mt-1">{storageLine}</p>
+				)}
+				{showDetails && description && (
+					<p className="text-sm border-t border-t-white mt-2 pt-2">
+						{description}
+					</p>
+				)}
 			</article>
 		);
 	}


### PR DESCRIPTION
The small ConfigCard branch returned early with only name and rarity, so the costLabel, refundLabel and description already passed by ConfigCard.component were silently dropped in the shop's installed row.

Adds an opt-in showDetails prop rather than growing the small card unconditionally: PollActiveConfigStrip, PollOptionRow and PipelineFailureScreen share size="small" and must stay compact.

DVTD-w9zc